### PR TITLE
Allow E-Mail OTP being set as alternative

### DIFF
--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
@@ -30,7 +30,8 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
     }
 
     public static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
-            AuthenticationExecutionModel.Requirement.REQUIRED, AuthenticationExecutionModel.Requirement.DISABLED
+            AuthenticationExecutionModel.Requirement.REQUIRED, AuthenticationExecutionModel.Requirement.ALTERNATIVE,
+            AuthenticationExecutionModel.Requirement.DISABLED
     };
 
     @Override


### PR DESCRIPTION
I would like to set the e-mail OTP as alternative when somebody has not set a more convenient 2FA. After testing alternative works like somebody would expect.