### PR TITLE
catch exception when no or invalid code is entered

### DIFF
--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -80,8 +80,14 @@ public class EmailAuthenticatorForm implements Authenticator {
             return;
         }
 
-        int givenEmailCode = Integer.parseInt(formData.getFirst(EMAIL_CODE));
-        boolean valid = validateCode(context, givenEmailCode);
+        boolean valid;
+        try {
+            int givenEmailCode = Integer.parseInt(formData.getFirst(EMAIL_CODE));
+            valid = validateCode(context, givenEmailCode);
+        } catch (NumberFormatException e) {
+            valid = false;
+        }
+
         if (!valid) {
             context.getEvent().error(Errors.INVALID_USER_CREDENTIALS);
             challenge(context, new FormMessage(Messages.INVALID_ACCESS_CODE));


### PR DESCRIPTION
Just a small fix that was causing unexpected login error when user submitted an empty email code.