### PR TITLE
Added configurability, time-to-live and improved code generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ hs_err_pid*
 .DS_Store
 target/*
 .idea
+.vscode

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -160,8 +160,7 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
 
     private void sendEmailWithCode(RealmModel realm, UserModel user, String code, int ttl) {
         if (user.getEmail() == null) {
-            log.warnf("Could not send access code email due to missing email. realm=%s user=%s", realm.getId(),
-                    user.getUsername());
+            log.warnf("Could not send access code email due to missing email. realm=%s user=%s", realm.getId(), user.getUsername());
             throw new AuthenticationFlowException(AuthenticationFlowError.INVALID_USER);
         }
 
@@ -176,8 +175,7 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
             EmailTemplateProvider emailProvider = session.getProvider(EmailTemplateProvider.class);
             emailProvider.setRealm(realm);
             emailProvider.setUser(user);
-            // Don't forget to add the welcome-email.ftl (html and text) template to your
-            // theme.
+            // Don't forget to add the welcome-email.ftl (html and text) template to your theme.
             emailProvider.send("emailCodeSubject", subjectParams, "code-email.ftl", mailBodyAttributes);
         } catch (EmailException eex) {
             log.errorf(eex, "Failed to send access code email. realm=%s user=%s", realm.getId(), user.getUsername());

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -4,7 +4,6 @@ import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.AuthenticationFlowException;
-import org.keycloak.authentication.Authenticator;
 import org.keycloak.email.EmailException;
 import org.keycloak.email.EmailTemplateProvider;
 import org.keycloak.events.Errors;
@@ -24,9 +23,7 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 @JBossLog
-public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator implements Authenticator {
-
-    static final String ID = "demo-email-code-form";
+public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
 
     public static final String EMAIL_CODE = "emailCode";
 

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -66,11 +66,11 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
         }
 
         int length = EmailConstants.DEFAULT_LENGTH;
-		int ttl = EmailConstants.DEFAULT_TTL;
+        int ttl = EmailConstants.DEFAULT_TTL;
         if (config != null) {
             // get config values
             length = Integer.parseInt(config.getConfig().get(EmailConstants.CODE_LENGTH));
-		    ttl = Integer.parseInt(config.getConfig().get(EmailConstants.CODE_TTL));
+            ttl = Integer.parseInt(config.getConfig().get(EmailConstants.CODE_TTL));
         }
 
         String code = SecretGenerator.getInstance().randomString(length, SecretGenerator.DIGITS);
@@ -102,32 +102,31 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
 
         AuthenticationSessionModel session = context.getAuthenticationSession();
         String code = session.getAuthNote(EmailConstants.CODE);
-		String ttl = session.getAuthNote(EmailConstants.CODE_TTL);
+        String ttl = session.getAuthNote(EmailConstants.CODE_TTL);
         String enteredCode = formData.getFirst(EmailConstants.CODE);
 
-
         if (enteredCode.equals(code)) {
-			if (Long.parseLong(ttl) < System.currentTimeMillis()) {
-				// expired
+            if (Long.parseLong(ttl) < System.currentTimeMillis()) {
+                // expired
                 context.getEvent().user(userModel).error(Errors.EXPIRED_CODE);
                 Response challengeResponse = challenge(context, Messages.EXPIRED_ACTION_TOKEN_SESSION_EXISTS);
                 context.failureChallenge(AuthenticationFlowError.EXPIRED_CODE, challengeResponse);
-			} else {
-				// valid
+            } else {
+                // valid
                 resetEmailCode(context);
-				context.success();
-			}
-		} else {
-			// invalid
-			AuthenticationExecutionModel execution = context.getExecution();
-			if (execution.isRequired()) {
+                context.success();
+            }
+        } else {
+            // invalid
+            AuthenticationExecutionModel execution = context.getExecution();
+            if (execution.isRequired()) {
                 context.getEvent().user(userModel).error(Errors.INVALID_USER_CREDENTIALS);
                 Response challengeResponse = challenge(context, Messages.INVALID_ACCESS_CODE);
                 context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
-			} else if (execution.isConditional() || execution.isAlternative()) {
-				context.attempted();
-			}
-		}
+            } else if (execution.isConditional() || execution.isAlternative()) {
+                context.attempted();
+            }
+        }
     }
 
     @Override
@@ -161,7 +160,8 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
 
     private void sendEmailWithCode(RealmModel realm, UserModel user, String code, int ttl) {
         if (user.getEmail() == null) {
-            log.warnf("Could not send access code email due to missing email. realm=%s user=%s", realm.getId(), user.getUsername());
+            log.warnf("Could not send access code email due to missing email. realm=%s user=%s", realm.getId(),
+                    user.getUsername());
             throw new AuthenticationFlowException(AuthenticationFlowError.INVALID_USER);
         }
 
@@ -176,7 +176,8 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
             EmailTemplateProvider emailProvider = session.getProvider(EmailTemplateProvider.class);
             emailProvider.setRealm(realm);
             emailProvider.setUser(user);
-            // Don't forget to add the welcome-email.ftl (html and text) template to your theme.
+            // Don't forget to add the welcome-email.ftl (html and text) template to your
+            // theme.
             emailProvider.send("emailCodeSubject", subjectParams, "code-email.ftl", mailBodyAttributes);
         } catch (EmailException eex) {
             log.errorf(eex, "Failed to send access code email. realm=%s user=%s", realm.getId(), user.getUsername());

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -24,6 +24,12 @@ import java.util.concurrent.ThreadLocalRandom;
 
 @JBossLog
 public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
+    /**
+     * TODO
+     * - Add time to live (ttl)
+     * - Improve HTML Tempalte (maybe use Keycloak OTP screen with extensions)
+     * - (optional) Improve Email Template
+     */
 
     public static final String EMAIL_CODE = "emailCode";
 

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -30,7 +30,6 @@ import java.util.Map;
 public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
     /**
      * TODO
-     * - Add time to live (ttl)
      * - Improve HTML Tempalte (maybe use Keycloak OTP screen with extensions)
      * - (optional) Improve Email Template
      */
@@ -63,14 +62,13 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
     }
 
     private void generateAndSendEmailCode(AuthenticationFlowContext context) {
-        if (context.getAuthenticationSession().getAuthNote(EmailConstants.CODE) != null) {
-            // skip sending email code
-            return;
-        }
-
         AuthenticatorConfigModel config = context.getAuthenticatorConfig();
         AuthenticationSessionModel session = context.getAuthenticationSession();
 
+        if (session.getAuthNote(EmailConstants.CODE) != null) {
+            // skip sending email code
+            return;
+        }
 
         int length = Integer.parseInt(config.getConfig().get(EmailConstants.CODE_LENGTH));
 		int ttl = Integer.parseInt(config.getConfig().get(EmailConstants.CODE_TTL));
@@ -78,7 +76,6 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
         sendEmailWithCode(context.getRealm(), context.getUser(), code);
         session.setAuthNote(EmailConstants.CODE, code);
         session.setAuthNote(EmailConstants.CODE_TTL, Long.toString(System.currentTimeMillis() + (ttl * 1000L)));
-
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -28,11 +28,6 @@ import java.util.Map;
 
 @JBossLog
 public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
-    /**
-     * TODO
-     * - Improve HTML Tempalte (maybe use Keycloak OTP screen with extensions)
-     * - (optional) Improve Email Template
-     */
     private final KeycloakSession session;
 
     public EmailAuthenticatorForm(KeycloakSession session) {

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
@@ -56,9 +56,9 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
         return List.of(
-            new ProviderConfigProperty("length", "Code length", "The number of digits of the generated code.",
+            new ProviderConfigProperty(EmailConstants.CODE_LENGTH, "Code length", "The number of digits of the generated code.",
                 ProviderConfigProperty.STRING_TYPE, "6"),
-            new ProviderConfigProperty("ttl", "Time-to-live",
+            new ProviderConfigProperty(EmailConstants.CODE_TTL, "Time-to-live",
                 "The time to live in seconds for the code to be valid.", ProviderConfigProperty.STRING_TYPE,
                 "300"));
     }

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
@@ -57,10 +57,10 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
     public List<ProviderConfigProperty> getConfigProperties() {
         return List.of(
             new ProviderConfigProperty(EmailConstants.CODE_LENGTH, "Code length", "The number of digits of the generated code.",
-                ProviderConfigProperty.STRING_TYPE, "6"),
+                ProviderConfigProperty.STRING_TYPE, String.valueOf(EmailConstants.DEFAULT_LENGTH)),
             new ProviderConfigProperty(EmailConstants.CODE_TTL, "Time-to-live",
                 "The time to live in seconds for the code to be valid.", ProviderConfigProperty.STRING_TYPE,
-                "300"));
+                String.valueOf(EmailConstants.DEFAULT_TTL)));
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
@@ -13,6 +13,10 @@ import java.util.List;
 
 @AutoService(AuthenticatorFactory.class)
 public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
+    @Override
+    public String getId() {
+        return "email-authenticator";
+    }
 
     @Override
     public String getDisplayType() {
@@ -21,12 +25,12 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
 
     @Override
     public String getReferenceCategory() {
-        return null;
+        return "otp";
     }
 
     @Override
     public boolean isConfigurable() {
-        return false;
+        return true;
     }
 
     public static final AuthenticationExecutionModel.Requirement[] REQUIREMENT_CHOICES = {
@@ -51,7 +55,12 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
 
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
-        return null;
+        return List.of(
+            new ProviderConfigProperty("length", "Code length", "The number of digits of the generated code.",
+                ProviderConfigProperty.STRING_TYPE, "6"),
+            new ProviderConfigProperty("ttl", "Time-to-live",
+                "The time to live in seconds for the code to be valid.", ProviderConfigProperty.STRING_TYPE,
+                "300"));
     }
 
     @Override
@@ -72,10 +81,5 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
     @Override
     public void postInit(KeycloakSessionFactory factory) {
         // NOOP
-    }
-
-    @Override
-    public String getId() {
-        return EmailAuthenticatorForm.ID;
     }
 }

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
@@ -56,11 +56,12 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
     @Override
     public List<ProviderConfigProperty> getConfigProperties() {
         return List.of(
-            new ProviderConfigProperty(EmailConstants.CODE_LENGTH, "Code length", "The number of digits of the generated code.",
-                ProviderConfigProperty.STRING_TYPE, String.valueOf(EmailConstants.DEFAULT_LENGTH)),
-            new ProviderConfigProperty(EmailConstants.CODE_TTL, "Time-to-live",
-                "The time to live in seconds for the code to be valid.", ProviderConfigProperty.STRING_TYPE,
-                String.valueOf(EmailConstants.DEFAULT_TTL)));
+                new ProviderConfigProperty(EmailConstants.CODE_LENGTH, "Code length",
+                        "The number of digits of the generated code.",
+                        ProviderConfigProperty.STRING_TYPE, String.valueOf(EmailConstants.DEFAULT_LENGTH)),
+                new ProviderConfigProperty(EmailConstants.CODE_TTL, "Time-to-live",
+                        "The time to live in seconds for the code to be valid.", ProviderConfigProperty.STRING_TYPE,
+                        String.valueOf(EmailConstants.DEFAULT_TTL)));
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
@@ -1,0 +1,10 @@
+package com.mesutpiskin.keycloak.auth.email;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class EmailConstants {
+	public String CODE = "code";
+	public String CODE_LENGTH = "length";
+	public String CODE_TTL = "ttl";
+}

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
@@ -7,4 +7,6 @@ public class EmailConstants {
 	public String CODE = "emailCode";
 	public String CODE_LENGTH = "length";
 	public String CODE_TTL = "ttl";
+	public int DEFAULT_LENGTH = 6;
+	public int DEFAULT_TTL = 300;
 }

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
@@ -4,7 +4,7 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class EmailConstants {
-	public String CODE = "code";
+	public String CODE = "emailCode";
 	public String CODE_LENGTH = "length";
 	public String CODE_TTL = "ttl";
 }

--- a/src/main/resources/theme-resources/templates/email-code-form.ftl
+++ b/src/main/resources/theme-resources/templates/email-code-form.ftl
@@ -1,27 +1,43 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=true; section>
-    <#if section = "title">
-        Access Code Form
-    <#elseif section = "header">
-        Access Code Form
-    <#elseif section = "form">
-        <p>Enter access code</p>
-        <form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-u2f-login-form" method="post">
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('emailCode'); section>
+    <#if section="header">
+        ${msg("doLogIn")}
+    <#elseif section="form">
+        <form id="kc-otp-login-form" class="${properties.kcFormClass!}" action="${url.loginAction}"
+            method="post">
+
             <div class="${properties.kcFormGroupClass!}">
-                <label for="emailCode">Access Code</label>
-                <input id="emailCode" name="emailCode" type="text" inputmode="numeric" pattern="[0-9]*"/>
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="emailCode" class="${properties.kcLabelClass!}">${msg("loginOtpOneTime")}</label>
+                </div>
+
+            <div class="${properties.kcInputWrapperClass!}">
+                <input id="emailCode" name="emailCode" autocomplete="off" type="text" class="${properties.kcInputClass!}"
+                       autofocus aria-invalid="<#if messagesPerField.existsError('emailCode')>true</#if>"/>
+
+                <#if messagesPerField.existsError('emailCode')>
+                    <span id="input-error-otp-code" class="${properties.kcInputErrorMessageClass!}"
+                          aria-live="polite">
+                        ${kcSanitize(messagesPerField.get('emailCode'))?no_esc}
+                    </span>
+                </#if>
             </div>
+        </div>
 
-            <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
-                   type="submit" value="${msg("doSubmit")}"/>
-
-            <input name="resend"
-                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
-                   type="submit" value="${msg("resendCode")}"/>
-
-            <input name="cancel"
-                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
-                   type="submit" value="${msg("doCancel")}"/>
+            <div class="${properties.kcFormGroupClass!}">
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                    </div>
+                </div>
+                
+                <div id="kc-form-buttons">
+                    <div class="${properties.kcFormButtonsWrapperClass!}">
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" name="login" type="submit" value="${msg("doSubmit")}" />
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" name="resend" type="submit" value="${msg("resendCode")}"/>
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" name="cancel" type="submit" value="${msg("doCancel")}"/>
+                    </div>
+                </div>
+            </div>
         </form>
     </#if>
 </@layout.registrationLayout>

--- a/src/main/resources/theme-resources/templates/email-code-form.ftl
+++ b/src/main/resources/theme-resources/templates/email-code-form.ftl
@@ -1,43 +1,27 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayMessage=!messagesPerField.existsError('emailCode'); section>
-    <#if section="header">
-        ${msg("doLogIn")}
-    <#elseif section="form">
-        <form id="kc-otp-login-form" class="${properties.kcFormClass!}" action="${url.loginAction}"
-            method="post">
-
+<@layout.registrationLayout displayInfo=true; section>
+    <#if section = "title">
+        Access Code Form
+    <#elseif section = "header">
+        Access Code Form
+    <#elseif section = "form">
+        <p>Enter access code</p>
+        <form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-u2f-login-form" method="post">
             <div class="${properties.kcFormGroupClass!}">
-                <div class="${properties.kcLabelWrapperClass!}">
-                    <label for="emailCode" class="${properties.kcLabelClass!}">${msg("loginOtpOneTime")}</label>
-                </div>
-
-            <div class="${properties.kcInputWrapperClass!}">
-                <input id="emailCode" name="emailCode" autocomplete="off" type="text" class="${properties.kcInputClass!}"
-                       autofocus aria-invalid="<#if messagesPerField.existsError('emailCode')>true</#if>"/>
-
-                <#if messagesPerField.existsError('emailCode')>
-                    <span id="input-error-otp-code" class="${properties.kcInputErrorMessageClass!}"
-                          aria-live="polite">
-                        ${kcSanitize(messagesPerField.get('emailCode'))?no_esc}
-                    </span>
-                </#if>
+                <label for="emailCode">Access Code</label>
+                <input id="emailCode" name="emailCode" type="text" inputmode="numeric" pattern="[0-9]*"/>
             </div>
-        </div>
 
-            <div class="${properties.kcFormGroupClass!}">
-                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
-                    <div class="${properties.kcFormOptionsWrapperClass!}">
-                    </div>
-                </div>
-                
-                <div id="kc-form-buttons">
-                    <div class="${properties.kcFormButtonsWrapperClass!}">
-                        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" name="login" type="submit" value="${msg("doSubmit")}" />
-                        <input class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" name="resend" type="submit" value="${msg("resendCode")}"/>
-                        <input class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" name="cancel" type="submit" value="${msg("doCancel")}"/>
-                    </div>
-                </div>
-            </div>
+            <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
+                   type="submit" value="${msg("doSubmit")}"/>
+
+            <input name="resend"
+                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
+                   type="submit" value="${msg("resendCode")}"/>
+
+            <input name="cancel"
+                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
+                   type="submit" value="${msg("doCancel")}"/>
         </form>
     </#if>
 </@layout.registrationLayout>

--- a/src/main/resources/theme/email-code-theme/email/html/code-email.ftl
+++ b/src/main/resources/theme/email-code-theme/email/html/code-email.ftl
@@ -1,5 +1,5 @@
 <html>
 <body>
-${kcSanitize(msg("emailCodeBody", code))?no_esc}
+${kcSanitize(msg("emailCodeBody", code, ttl))?no_esc}
 </body>
 </html>

--- a/src/main/resources/theme/email-code-theme/email/messages/messages_en.properties
+++ b/src/main/resources/theme/email-code-theme/email/messages/messages_en.properties
@@ -1,3 +1,3 @@
 emailCodeSubject={0} access code
-emailCodeBody=Access code: {0}\n\nThis code will expire within {1} seconds.
+emailCodeBody=Access code: {0}.\n\nThis code will expire within {1} seconds.
 resendCode=Resend Code

--- a/src/main/resources/theme/email-code-theme/email/messages/messages_en.properties
+++ b/src/main/resources/theme/email-code-theme/email/messages/messages_en.properties
@@ -1,3 +1,3 @@
 emailCodeSubject={0} access code
-emailCodeBody=Access code: {0}
+emailCodeBody=Access code: {0}\n\nThis code will expire within {1} seconds.
 resendCode=Resend Code

--- a/src/main/resources/theme/email-code-theme/email/text/code-email.ftl
+++ b/src/main/resources/theme/email-code-theme/email/text/code-email.ftl
@@ -1,2 +1,2 @@
 <#ftl output_format="plainText">
-${msg("emailCodeBody", code)}
+${msg("emailCodeBody", code, ttl)}


### PR DESCRIPTION
First of all great job with this repo. I think 2FA with email is a very crucial feature and it was nice to see what work has already been done here. I would like to make this repo extremely easy to use for anyone that wants to add 2FA to their project.

Therefore I am suggesting the following improvements which should make this feature more secure and more easy to adjust to different use cases:

- [x] Added time-to-live so the code is only valid for a certain amount of seconds
- [x] Added configuration options for the code length and the time-to-live
- [x] Fix #24 by using Keycloak's `SecretGenerator` instead of `ThreadLocalRandom`

Some inspiration regarding the TTL and configurability was taken from this repo https://github.com/stratumn/keycloak-2fa-email-authenticator
