### PR TITLE
Align template with Keycloak OTP screen

### DIFF
--- a/src/main/resources/theme-resources/templates/email-code-form.ftl
+++ b/src/main/resources/theme-resources/templates/email-code-form.ftl
@@ -1,27 +1,43 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=true; section>
-    <#if section = "title">
-        Access Code Form
-    <#elseif section = "header">
-        Access Code Form
-    <#elseif section = "form">
-        <p>Enter access code</p>
-        <form action="${url.loginAction}" class="${properties.kcFormClass!}" id="kc-u2f-login-form" method="post">
+<@layout.registrationLayout displayMessage=!messagesPerField.existsError('emailCode'); section>
+    <#if section="header">
+        ${msg("doLogIn")}
+    <#elseif section="form">
+        <form id="kc-otp-login-form" class="${properties.kcFormClass!}" action="${url.loginAction}"
+            method="post">
+
             <div class="${properties.kcFormGroupClass!}">
-                <label for="emailCode">Access Code</label>
-                <input id="emailCode" name="emailCode" type="text" inputmode="numeric" pattern="[0-9]*"/>
+                <div class="${properties.kcLabelWrapperClass!}">
+                    <label for="emailCode" class="${properties.kcLabelClass!}">${msg("loginOtpOneTime")}</label>
+                </div>
+
+            <div class="${properties.kcInputWrapperClass!}">
+                <input id="emailCode" name="emailCode" autocomplete="off" type="text" class="${properties.kcInputClass!}"
+                       autofocus aria-invalid="<#if messagesPerField.existsError('emailCode')>true</#if>"/>
+
+                <#if messagesPerField.existsError('emailCode')>
+                    <span id="input-error-otp-code" class="${properties.kcInputErrorMessageClass!}"
+                          aria-live="polite">
+                        ${kcSanitize(messagesPerField.get('emailCode'))?no_esc}
+                    </span>
+                </#if>
             </div>
+        </div>
 
-            <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
-                   type="submit" value="${msg("doSubmit")}"/>
+            <div class="${properties.kcFormGroupClass!}">
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!}">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                    </div>
+                </div>
 
-            <input name="resend"
-                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
-                   type="submit" value="${msg("resendCode")}"/>
-
-            <input name="cancel"
-                   class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}"
-                   type="submit" value="${msg("doCancel")}"/>
+                <div id="kc-form-buttons">
+                    <div class="${properties.kcFormButtonsWrapperClass!}">
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonLargeClass!}" name="login" type="submit" value="${msg("doSubmit")}" />
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" name="resend" type="submit" value="${msg("resendCode")}"/>
+                        <input class="${properties.kcButtonClass!} ${properties.kcButtonDefaultClass!} ${properties.kcButtonLargeClass!}" name="cancel" type="submit" value="${msg("doCancel")}"/>
+                    </div>
+                </div>
+            </div>
         </form>
     </#if>
 </@layout.registrationLayout>


### PR DESCRIPTION
Keycloak already has a very similar screen for entering the OTP code, it is just missing the additional buttons for `resend code` and `cancel` (https://github.com/keycloak/keycloak/blob/main/themes/src/main/resources/theme/base/login/login-otp.ftl).
I have copied and adjusted this template to the requirements here. 
I think it is a good idea to be more close to the Keycloak style.

Before:

<img width="685" alt="Screenshot 2023-10-18 at 15 08 38" src="https://github.com/mesutpiskin/keycloak-2fa-email-authenticator/assets/33730997/ca69e775-4874-420c-8542-f87f570e30f8">

After:

<img width="704" alt="Screenshot 2023-10-18 at 15 11 49" src="https://github.com/mesutpiskin/keycloak-2fa-email-authenticator/assets/33730997/c692be36-7d92-45ce-88aa-70944ba94824">
