### PR TITLE
Update README.md - OTP flow after Username/pwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Don't forget to configure your realm's SMTP settings, otherwise no email will be
 4. Click on the `Email`-tab and enter your smpt data.
 
 ## Authentication Flow
-Create new browser login authentication flow and add Email OTP flow before Username Password Form.
+Create new browser login authentication flow and add Email OTP flow after Username Password Form.
 
 <img src="static/otp-form.png">


### PR DESCRIPTION
The OTP flow must be after the Username/Password  otherwise Keycloak doesn't have the email to send the OTP.