### PR TITLE
Set `configuredFor` if the user has an email

### DIFF
--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -145,7 +145,7 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
 
     @Override
     public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
-        return true;
+        return user.getEmail() != null;
     }
 
     @Override


### PR DESCRIPTION
The goal of this PR is to implement the `configuredFor` method.
It returns true if the user has an email. Otherwise, it returns false.
This is to prevent using the Email OTP when the user has no email.