### PR TITLE
Fix Java version based on the pom file

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -6,6 +6,7 @@ name: Maven Package
 on:
   release:
     types: [released]
+  workflow_dispatch:
 
 jobs:
   kc-version-matrix:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -9,32 +9,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  kc-version-matrix:
-    name: Get last 10 Keycloak versions
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - id: set-matrix
-        run: |
-          VERSIONS=$( curl -L -s https://api.github.com/repos/keycloak/keycloak/tags | jq -c 'sort_by(.name)[-11:-1] | [ .[] | .version=.name | {version}]' )
-          echo "::set-output name=matrix::{\"include\":$VERSIONS}"
-
   build:
-    needs: kc-version-matrix
     runs-on: ubuntu-latest
-    strategy:
-      matrix: ${{fromJson(needs.kc-version-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: maven
       - name: Set version
-        run: mvn versions:set -DnewVersion=$(git describe --tags)-KC${{ matrix.version }}
+        run: mvn versions:set -DnewVersion=$(git describe --tags)-KC-25.0.5
       - name: Build with Maven
         run: mvn -Dkeycloak.version=${{ matrix.version }} -B package --file pom.xml
       - name: Release

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Also add a workflow_dispatch that allows you to manually run the build workflow, the reasoning is that outsiders usually can't see the build logs (at least I couldn't) to propose fixes directly and whenever we fork the repo to test out the build the CI is not triggered automatically, which means we need to make a dummy commit to see the errors before working on them.

Cheers.