### PR TITLE
Improve plugin copy

### DIFF
--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,0 +1,2 @@
+resendCode=Resend Code
+emailOtpForm=Please enter the six digit code that was delivered to your email.

--- a/src/main/resources/theme-resources/messages/messages_tr.properties
+++ b/src/main/resources/theme-resources/messages/messages_tr.properties
@@ -1,0 +1,1 @@
+resendCode=Tekrar Gönder

--- a/src/main/resources/theme-resources/templates/email-code-form.ftl
+++ b/src/main/resources/theme-resources/templates/email-code-form.ftl
@@ -8,7 +8,7 @@
 
             <div class="${properties.kcFormGroupClass!}">
                 <div class="${properties.kcLabelWrapperClass!}">
-                    <label for="emailCode" class="${properties.kcLabelClass!}">${msg("loginOtpOneTime")}</label>
+                    <label for="emailCode" class="${properties.kcLabelClass!}">${msg("emailOtpForm")}</label>
                 </div>
 
             <div class="${properties.kcInputWrapperClass!}">

--- a/src/main/resources/theme/email-code-theme/email/messages/messages_en.properties
+++ b/src/main/resources/theme/email-code-theme/email/messages/messages_en.properties
@@ -1,3 +1,2 @@
 emailCodeSubject={0} access code
 emailCodeBody=Access code: {0}.\n\nThis code will expire within {1} seconds.
-resendCode=Resend Code

--- a/src/main/resources/theme/email-code-theme/email/messages/messages_tr.properties
+++ b/src/main/resources/theme/email-code-theme/email/messages/messages_tr.properties
@@ -1,3 +1,2 @@
 emailCodeSubject={0} dogrulama kodu
 emailCodeBody=Dogrulama kodunuz: {0}
-resendCode=Tekrar Gönder


### PR DESCRIPTION
Hey, thanks for making this in a proper open license.

This MR just improves the copy of the plugin, as with the old phrasing, it wasn't clear to the end user that an email was delivered, as it just used the standard OTP copy. I didn't add a `tr` message as i don't know the language.

I also fixed resendCode not being templated correctly while I was at it (messages for the template should be next to the template)