### PR TITLE
removed lombok, update java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,17 +5,16 @@
 
     <artifactId>keycloak-2fa-email-authenticator</artifactId>
     <groupId>com.mesutpiskin.keycloak</groupId>
-    <version>1.0.0.0-SNAPSHOT</version>
+    <version>26.0.0-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <lombok.version>1.18.36</lombok.version>
-        <keycloak.version>26.1.1</keycloak.version>
+        <keycloak.version>26.0.0</keycloak.version>
         <maven-jar.plugin.version>3.4.2</maven-jar.plugin.version>
     </properties>
 
@@ -41,14 +40,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
     </dependencies>
 
     <build>
@@ -68,6 +59,7 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+                
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -1,7 +1,5 @@
 package com.mesutpiskin.keycloak.auth.email;
 
-import lombok.extern.jbosslog.JBossLog;
-
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.AuthenticationFlowError;
 import org.keycloak.authentication.AuthenticationFlowException;
@@ -20,14 +18,16 @@ import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
 import org.keycloak.common.util.SecretGenerator;
 
+import org.jboss.logging.Logger;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@JBossLog
 public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
+
+      protected static final Logger logger = Logger.getLogger(EmailAuthenticatorForm.class);
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
@@ -154,7 +154,7 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
 
     private void sendEmailWithCode(KeycloakSession session, RealmModel realm, UserModel user, String code, int ttl) {
         if (user.getEmail() == null) {
-            log.warnf("Could not send access code email due to missing email. realm=%s user=%s", realm.getId(), user.getUsername());
+            logger.warnf("Could not send access code email due to missing email. realm=%s user=%s", realm.getId(), user.getUsername());
             throw new AuthenticationFlowException(AuthenticationFlowError.INVALID_USER);
         }
 
@@ -172,7 +172,7 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
             // Don't forget to add the welcome-email.ftl (html and text) template to your theme.
             emailProvider.send("emailCodeSubject", subjectParams, "code-email.ftl", mailBodyAttributes);
         } catch (EmailException eex) {
-            log.errorf(eex, "Failed to send access code email. realm=%s user=%s", realm.getId(), user.getUsername());
+            logger.errorf(eex, "Failed to send access code email. realm=%s user=%s", realm.getId(), user.getUsername());
         }
     }
 }

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
@@ -1,12 +1,9 @@
 package com.mesutpiskin.keycloak.auth.email;
 
-import lombok.experimental.UtilityClass;
-
-@UtilityClass
 public class EmailConstants {
-	public String CODE = "emailCode";
-	public String CODE_LENGTH = "length";
-	public String CODE_TTL = "ttl";
-	public int DEFAULT_LENGTH = 6;
-	public int DEFAULT_TTL = 300;
+	public static String CODE = "emailCode";
+	public static String CODE_LENGTH = "length";
+	public static String CODE_TTL = "ttl";
+	public static int DEFAULT_LENGTH = 6;
+	public static int DEFAULT_TTL = 300;
 }


### PR DESCRIPTION
Removed Lombok dependency, prefer use native sutff for accessing static values.

Use Jboss logs instead of lombok.

Upgraded to Java 21, java 17 support is deprecated since Keycloak 25