### PR TITLE
feat: add OTP simulation mode for local development

### DIFF
--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -71,7 +71,11 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
         }
 
         String code = SecretGenerator.getInstance().randomString(length, SecretGenerator.DIGITS);
-        sendEmailWithCode(context.getSession(), context.getRealm(), context.getUser(), code, ttl);
+        if (config != null && Boolean.parseBoolean(config.getConfig().get(EmailConstants.SIMULATION_MODE))) {
+            logger.infof("***** SIMULATION MODE ***** Email code send to %s for user %s is: %s", context.getUser().getEmail(), context.getUser().getUsername(), code);
+        } else {
+            sendEmailWithCode(context.getSession(), context.getRealm(), context.getUser(), code, ttl);
+        }
         session.setAuthNote(EmailConstants.CODE, code);
         session.setAuthNote(EmailConstants.CODE_TTL, Long.toString(System.currentTimeMillis() + (ttl * 1000L)));
     }

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
@@ -61,7 +61,11 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
                         ProviderConfigProperty.STRING_TYPE, String.valueOf(EmailConstants.DEFAULT_LENGTH)),
                 new ProviderConfigProperty(EmailConstants.CODE_TTL, "Time-to-live",
                         "The time to live in seconds for the code to be valid.", ProviderConfigProperty.STRING_TYPE,
-                        String.valueOf(EmailConstants.DEFAULT_TTL)));
+                        String.valueOf(EmailConstants.DEFAULT_TTL)),
+                new ProviderConfigProperty(EmailConstants.SIMULATION_MODE, "Simulation mode (dev only)",
+                        "In simulation mode, the mail won't be sent, but printed to the server logs", ProviderConfigProperty.BOOLEAN_TYPE,
+                        Boolean.valueOf(EmailConstants.DEFAULT_SIMULATION_MODE))
+                );
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
@@ -4,6 +4,8 @@ public class EmailConstants {
 	public static String CODE = "emailCode";
 	public static String CODE_LENGTH = "length";
 	public static String CODE_TTL = "ttl";
+	public static String SIMULATION_MODE = "simulationMode";
 	public static int DEFAULT_LENGTH = 6;
 	public static int DEFAULT_TTL = 300;
+	public static boolean DEFAULT_SIMULATION_MODE = false;
 }


### PR DESCRIPTION
This adds a simulation mode that logs the generated OTP code directly in the console/logs instead of requiring a fully configured MTA/SMTP server during local development.

The implementation is inspired by the simulation mode used in https://github.com/netzbegruenung/keycloak-mfa-plugins.

This greatly simplifies local setup and testing of OTP-based authentication flows.