### PR TITLE
Stop redirecting user to 'Back to Application' on invalid auth

### DIFF
--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -119,14 +119,9 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator {
             }
         } else {
             // invalid
-            AuthenticationExecutionModel execution = context.getExecution();
-            if (execution.isRequired()) {
-                context.getEvent().user(userModel).error(Errors.INVALID_USER_CREDENTIALS);
-                Response challengeResponse = challenge(context, Messages.INVALID_ACCESS_CODE, EmailConstants.CODE);
-                context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
-            } else if (execution.isConditional() || execution.isAlternative()) {
-                context.attempted();
-            }
+            context.getEvent().user(userModel).error(Errors.INVALID_USER_CREDENTIALS);
+            Response challengeResponse = challenge(context, Messages.INVALID_ACCESS_CODE, EmailConstants.CODE);
+            context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
         }
     }
 


### PR DESCRIPTION
This commit targets the problem reported in [#61](https://github.com/mesutpiskin/keycloak-2fa-email-authenticator/issues/61) and adjusts the email 2FA authenticator to handle the failing case more gracefully.

The logic was behaving different for cases where email 2fa was required, conditional or alternatives were the exception.

In my use case, I have 3 two-factor alternatives that the user could use along as they have it configure: webauth, authenticator app and email. Only the email was redirecting the user to that page with "Back to application" message. After, these changes it was working fine for me.

My flow:
<img width="1557" height="524" alt="image" src="https://github.com/user-attachments/assets/df8635d3-e8b1-439b-92f2-d78792bdd7e9" />

Invalid code:
<img width="623" height="422" alt="image" src="https://github.com/user-attachments/assets/516a3468-f65f-4eb3-8db0-7ac7817e4e6b" />

I'd like to have that error message in red as it should be, but that's another issue for another day.
