### PR TITLE
Add Dockerfile and fix regex caching issues (Fixes #62)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Stage 1: Build the provider
+FROM maven:3.9-eclipse-temurin-21 AS builder
+
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+
+# Build the project
+RUN mvn clean package -DskipTests
+
+# Stage 2: Create the Keycloak image
+FROM quay.io/keycloak/keycloak:26.0.0
+
+# Copy the provider JAR from the builder stage
+COPY --from=builder /app/target/keycloak-2fa-email-authenticator-*.jar /opt/keycloak/providers/
+
+# Build Keycloak to include the provider
+RUN /opt/keycloak/bin/kc.sh build
+
+# Expose the port
+EXPOSE 8080
+
+# Entrypoint is inherited from the base image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  keycloak:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN_PASSWORD=admin
+    command: start-dev


### PR DESCRIPTION
- Add `Dockerfile` for multi-stage build (Maven + Keycloak 26).
- Add `docker-compose.yml` for easy local development.
- Fix regex pattern caching in `ConditionalEmailAuthenticatorForm` using static `ConcurrentHashMap`.
- Handle `PatternSyntaxException` to prevent crashes on invalid config.
- Update `pom.xml` manifest entries to `jakarta` namespace for Keycloak 26 compatibility.
- Add unit tests for regex logic and exception handling.