### PR TITLE
Solve multiple issues and cleanup

### DIFF
--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/ConditionalEmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/ConditionalEmailAuthenticatorForm.java
@@ -5,6 +5,7 @@ import static com.mesutpiskin.keycloak.auth.email.ConditionalEmailAuthenticatorF
 import static com.mesutpiskin.keycloak.auth.email.ConditionalEmailAuthenticatorForm.OtpDecision.SKIP_OTP;
 import static org.keycloak.models.utils.KeycloakModelUtils.getRoleFromString;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -13,6 +14,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
@@ -46,7 +48,8 @@ public class ConditionalEmailAuthenticatorForm extends EmailAuthenticatorForm {
 	@Override
     public void authenticate(AuthenticationFlowContext context) {
 
-        Map<String, String> config = context.getAuthenticatorConfig().getConfig();
+        AuthenticatorConfigModel model = context.getAuthenticatorConfig();
+        Map<String, String> config = model != null ? model.getConfig() : Collections.emptyMap();
 
         if (tryConcludeBasedOn(voteForUserOtpControlAttribute(context.getUser(), config), context)) {
             return;

--- a/src/main/resources/theme-resources/messages/messages_zh_TW.properties
+++ b/src/main/resources/theme-resources/messages/messages_zh_TW.properties
@@ -1,0 +1,5 @@
+resendCode=重送驗證碼
+emailOtpForm=請輸入發送至電子郵件信箱之6碼OTP驗證碼.
+
+emailCodeSubject={0} 存取驗證碼
+emailCodeBody=一次性驗證碼: {0}.\n\n此驗證碼將於 {1} 秒後失效.


### PR DESCRIPTION
- Fix NPE in `ConditionalEmailAuthenticatorForm` (Issue #57) by checking for null config.
- Add Traditional Chinese (zh_TW) translations (Issue #59).
- Fix regex pattern caching and error handling (Issue #62/unreported crash).
- Fully migrate `pom.xml` and source imports to `jakarta.*` for Keycloak 26 compatibility.
- Ensure no misleading comments remain regarding Issue #61.