### PR TITLE
Add release documentation and automation scripts

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,105 @@
+# 🚀 Release Guide
+
+This document explains how to publish new versions of the Keycloak 2FA Email Authenticator project.
+
+## Prerequisites
+
+- Maven must be installed
+- Git must be configured
+- You must have push access to the GitHub repository
+
+## Local Release Process
+
+### Method 1: FULLY AUTOMATED (GitHub CLI) - Easiest! 🚀
+
+If GitHub CLI is installed and you're logged in, **everything is handled with one command**:
+
+```bash
+./scripts/release-auto.sh v1.0.0 "Bug fixes and improvements"
+```
+
+The script **automatically**:
+- ✅ Builds JAR with Maven
+- ✅ Creates and pushes git tag
+- ✅ Creates GitHub Release
+- ✅ Uploads JAR file
+- ✅ Adds release notes
+- ✅ Shows download URL
+
+**FIRST TIME SETUP:**
+```bash
+# 1. Login to GitHub CLI (one time only)
+gh auth login
+
+# 2. Now you can release with one command!
+./scripts/release-auto.sh v1.0.0
+```
+
+### Method 2: Semi-Automated (without GitHub CLI)
+
+1. **Run the release script:**
+   ```bash
+   ./scripts/release.sh v1.0.0
+   ```
+   
+   The script does:
+   - ✅ Builds JAR with Maven
+   - ✅ Creates and pushes git tag
+   - ✅ Shows next steps
+
+2. **Create release on GitHub:**
+   - Go to: https://github.com/mesutpiskin/keycloak-2fa-email-authenticator/releases/new
+   - Select the tag you created (e.g., `v1.0.0`)
+   - Upload the JAR file from the `target/` directory
+   - Add release notes
+   - Click "Publish release"
+
+### Method 3: Manual
+
+1. **Build the JAR:**
+   ```bash
+   mvn clean package
+   ```
+
+2. **Create git tag:**
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+3. **Manual GitHub release:**
+   - Go to GitHub repo page
+   - `Releases` > `Create new release`
+   - Select tag and upload JAR
+
+## Version Numbering
+
+Use Semantic Versioning:
+- **Major (v2.0.0)**: Breaking changes
+- **Minor (v1.1.0)**: New features (backward compatible)
+- **Patch (v1.0.1)**: Bug fixes
+
+## Release Notes Template
+
+```markdown
+## What's Changed
+- Feature 1 description
+- Bug fix description
+
+## Installation
+Download the JAR and place it in your Keycloak `providers/` directory.
+
+## Compatibility
+- Keycloak 26.0.0+
+- Java 21+
+```
+
+## Checklist
+
+- [ ] Tests passing (`mvn test`)
+- [ ] README up to date
+- [ ] Version number correct
+- [ ] CHANGELOG updated (if applicable)
+- [ ] Tag created
+- [ ] JAR uploaded to GitHub
+- [ ] Release notes added

--- a/scripts/release-auto.sh
+++ b/scripts/release-auto.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Keycloak 2FA Email Authenticator - FULLY AUTOMATED Release Script
+# This script handles JAR build, tag creation, and GitHub Release in one command
+
+set -e  # Exit on error
+
+echo "🚀 Keycloak 2FA Email Authenticator - Starting Automated Release..."
+echo ""
+
+# Version check
+if [ -z "$1" ]; then
+    echo "❌ Error: You must specify a version!"
+    echo "Usage: ./release-auto.sh v1.0.0 \"Release notes (optional)\""
+    exit 1
+fi
+
+VERSION=$1
+RELEASE_NOTES=${2:-"Release $VERSION"}
+
+echo "📦 Version: $VERSION"
+echo "📝 Release Notes: $RELEASE_NOTES"
+echo ""
+
+# GitHub CLI check
+if ! command -v gh &> /dev/null; then
+    echo "❌ GitHub CLI (gh) is not installed!"
+    echo "To install: brew install gh"
+    echo "Alternative: Use ./release.sh (manual upload)"
+    exit 1
+fi
+
+# GitHub auth check
+if ! gh auth status &> /dev/null; then
+    echo "❌ You are not logged into GitHub!"
+    echo "To login, run: gh auth login"
+    exit 1
+fi
+
+# Clean and build
+echo "🔨 Starting Maven build (skipping tests)..."
+mvn clean package -DskipTests
+
+# Build check
+JAR_FILE=$(find target -name "keycloak-2fa-email-authenticator*.jar" -type f | head -n 1)
+if [ -z "$JAR_FILE" ]; then
+    echo "❌ JAR file not found!"
+    exit 1
+fi
+
+echo "✅ Build successful: $JAR_FILE"
+echo ""
+
+# Git tag check - ask if tag exists
+if git rev-parse "$VERSION" >/dev/null 2>&1; then
+    echo "⚠️  Tag '$VERSION' already exists!"
+    read -p "Do you want to continue? Existing tag will be used. (y/n): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "❌ Cancelled."
+        exit 1
+    fi
+else
+    # Create git tag
+    echo "🏷️  Creating git tag: $VERSION"
+    git tag -a "$VERSION" -m "Release $VERSION"
+    git push origin "$VERSION"
+    echo "✅ Tag created and pushed"
+fi
+
+echo ""
+
+# Create GitHub Release
+echo "📤 Creating GitHub Release..."
+gh release create "$VERSION" \
+    "$JAR_FILE" \
+    --title "Keycloak 2FA Email Authenticator $VERSION" \
+    --notes "$RELEASE_NOTES"
+
+echo ""
+echo "✅ Release completed successfully!"
+echo ""
+echo "🌐 Release URL:"
+gh release view "$VERSION" --web || echo "   https://github.com/mesutpiskin/keycloak-2fa-email-authenticator/releases/tag/$VERSION"
+echo ""
+echo "📥 Download URL:"
+echo "   https://github.com/mesutpiskin/keycloak-2fa-email-authenticator/releases/download/$VERSION/keycloak-2fa-email-authenticator-v$VERSION.jar"
+echo ""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Keycloak 2FA Email Authenticator - Local Release Script
+# This script builds the JAR file and provides upload instructions
+
+set -e  # Exit on error
+
+echo "🚀 Keycloak 2FA Email Authenticator - Starting Release..."
+echo ""
+
+# Version check
+if [ -z "$1" ]; then
+    echo "❌ Error: You must specify a version!"
+    echo "Usage: ./release.sh v1.0.0"
+    exit 1
+fi
+
+VERSION=$1
+echo "📦 Version: $VERSION"
+echo ""
+
+# Clean and build
+echo "🔨 Starting Maven build (skipping tests)..."
+mvn clean package -DskipTests
+
+# Build check
+JAR_FILE=$(find target -name "keycloak-2fa-email-authenticator*.jar" -type f)
+if [ -z "$JAR_FILE" ]; then
+    echo "❌ JAR file not found!"
+    exit 1
+fi
+
+echo "✅ Build successful: $JAR_FILE"
+echo ""
+
+# Create git tag
+echo "🏷️  Creating git tag: $VERSION"
+git tag -a "$VERSION" -m "Release $VERSION"
+git push origin "$VERSION"
+
+echo ""
+echo "✅ Release preparation complete!"
+echo ""
+echo "📋 Next Steps:"
+echo "1. Go to this URL on GitHub:"
+echo "   https://github.com/mesutpiskin/keycloak-2fa-email-authenticator/releases/new"
+echo ""
+echo "2. Select '$VERSION' as the tag"
+echo ""
+echo "3. Upload the following JAR file:"
+echo "   $JAR_FILE"
+echo ""
+echo "4. Add release notes and click 'Publish release'"
+echo ""


### PR DESCRIPTION
Introduces a detailed release guide in docs/RELEASE.md and adds two scripts: release-auto.sh for fully automated releases using GitHub CLI, and release.sh for semi-automated local releases. These additions streamline and document the process for building, tagging, and publishing new versions.