### PR TITLE
ci: Publish release to maven central

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -13,11 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      fail-fast: false
     steps:
       - id: set-matrix
         run: |
-          VERSIONS=$( curl -L -s https://api.github.com/repos/keycloak/keycloak/tags | jq -c 'sort_by(.name)[-11:-1] | [ .[] | .version=.name | {version}]' )
-          echo "::set-output name=matrix::{\"include\":$VERSIONS}"
+          VERSIONS=$( curl -L -s https://api.github.com/repos/keycloak/keycloak/releases | jq -c 'sort_by(.name)[-11:-1] | [ .[] | .version=.name | {version}]' )
+          echo "matrix={\"include\":$VERSIONS}" >> $GITHUB_OUTPUT
 
   build:
     needs: kc-version-matrix
@@ -26,20 +27,31 @@ jobs:
       matrix: ${{fromJson(needs.kc-version-matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
-      - name: Set version
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Set version corresponding to Keycloak version
         run: mvn versions:set -DnewVersion=$(git describe --tags)-KC${{ matrix.version }}
-      - name: Build with Maven
-        run: mvn -Dkeycloak.version=${{ matrix.version }} -B package --file pom.xml
-      - name: Release
+      - name: Build and publish to maven central
+        run: mvn -Dkeycloak.version=${{ matrix.version }} -B deploy --file pom.xml -P release --batch-mode 
+        env:
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSWORD }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+      - name: Attach artifact to release
         uses: softprops/action-gh-release@v1
         with:
           files: target/keycloak-2fa-email-authenticator*
           name: Keycloak 2FA Email Authenticator v${{ github.event.release.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
-    <artifactId>keycloak-2fa-email-authenticator</artifactId>
-    <groupId>com.mesutpiskin.keycloak</groupId>
-    <version>26.2.0</version>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <packaging>jar</packaging>
+
+    <groupId>com.mesutpiskin.keycloak</groupId>
+    <artifactId>keycloak-2fa-email-authenticator</artifactId>
+    <version>26.2.0</version>
+
+    <name>Keycloak 2FA email authenticator</name>
+    <description>A keycloak authenticator for 2FA via email</description>
+    <url>https://github.com/mesutpiskin/keycloak-2fa-email-authenticator</url>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Mesut Pişkin</name>
+            <email>mesutpiskin@outlook.com</email>
+            <organization>mesutpiskin</organization>
+            <organizationUrl>https://github.com/mesutpiskin/keycloak-2fa-email-authenticator</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/mesutpiskin/keycloak-2fa-email-authenticator.git</connection>
+        <developerConnection>scm:git:ssh://github.com:mesutpiskin/keycloak-2fa-email-authenticator.git</developerConnection>
+        <url>http://github.com/mesutpiskin/keycloak-2fa-email-authenticator/tree/main</url>
+    </scm>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -112,9 +136,82 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
-                
+
             </plugin>
         </plugins>
         <finalName>${project.artifactId}-v${project.version}</finalName>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.4.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <tokenAuth>true</tokenAuth>
+                            <autoPublish>true</autoPublish>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadoc</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <stylesheet>java</stylesheet>
+                            <doclint>none</doclint>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
This is a PR to:
- replace deprecated "set-output name" github action by $GITHUB_OUTPUT;
- Use keycloak releases list instead of tags list to build extensions jars;
- Deploy to maven central.

I have successfully deployed to my custom sonatype maven central namespace.
@mesutpiskin, if you want to merge this PR, you must create your own GPG keys, upload you private key to github repository secret to sign artifacts and upload the public key to keyserver.ubuntu.com using  `gpg -v --keyserver keyserver.ubuntu.com --send-keys your_email` command.
All instructions are in https://medium.com/@jtbsorensen/publish-your-artifact-to-the-maven-central-repository-using-github-actions-15d3b5d9ce88.

Regards.