### PR TITLE
Fix OTP security: constant-time comparison and plain-text storage in authNote

### DIFF
--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -24,7 +24,6 @@ import org.jboss.logging.Logger;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
-import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -139,7 +138,8 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
         } else {
             sendEmailWithCode(context, code, ttl);
         }
-        session.setAuthNote(EmailConstants.CODE, code);
+
+        session.setAuthNote(EmailConstants.CODE, OtpHashUtils.hash(code));
         long now = System.currentTimeMillis();
         session.setAuthNote(EmailConstants.CODE_TTL, Long.toString(now + (ttl * 1000L)));
         session.setAuthNote(EmailConstants.CODE_RESEND_AVAILABLE_AFTER, Long.toString(now + (resendCooldown * 1000L)));
@@ -277,7 +277,7 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
             return false;
         }
 
-        if (MessageDigest.isEqual(codeContext.submittedCode().getBytes(), codeContext.storedCode().getBytes())) {
+        if (OtpHashUtils.matches(codeContext.submittedCode(), codeContext.storedCode())) {
             return true;
         }
 

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -23,6 +23,8 @@ import org.keycloak.credential.CredentialProvider;
 import org.jboss.logging.Logger;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+
+import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -275,8 +277,9 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
             return false;
         }
 
-        if (codeContext.submittedCode().equals(codeContext.storedCode()))
+        if (MessageDigest.isEqual(codeContext.submittedCode().getBytes(), codeContext.storedCode().getBytes())) {
             return true;
+        }
 
         context.getEvent().user(user).error(Errors.INVALID_USER_CREDENTIALS);
 

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/OtpHashUtils.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/OtpHashUtils.java
@@ -1,0 +1,78 @@
+package com.mesutpiskin.keycloak.auth.email;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+/**
+ * Utility class for OTP hashing operations.
+ * <p>
+ * OTP codes are never persisted in plaintext. Before being stored in the
+ * authentication session, each code is hashed using {@value #HASH_ALGORITHM}.
+ * Validation is performed by hashing the submitted code and comparing the
+ * resulting digest against the stored hash.
+ * </p>
+ */
+final class OtpHashUtils {
+
+    /**
+     * The hashing algorithm used to protect OTP codes at rest.
+     * SHA-256 algorithm is mandated by the Java SE specification and is always available.
+     */
+    static final String HASH_ALGORITHM = "SHA-256";
+
+    private OtpHashUtils() {
+        throw new UnsupportedOperationException("OtpHashUtils is a utility class and cannot be instantiated");
+    }
+
+    /**
+     * Returns the {@value #HASH_ALGORITHM} hex digest of the given OTP code.
+     * <p>
+     * The raw code is never persisted; only the digest is stored in the
+     * authentication session. At validation time, use {@link #matches} to verify
+     * a submitted code against the stored digest.
+     * </p>
+     *
+     * @param code the raw OTP code (must not be {@code null})
+     * @return lowercase hex-encoded {@value #HASH_ALGORITHM} digest (64 characters)
+     * @throws IllegalStateException if {@value #HASH_ALGORITHM} is unexpectedly unavailable
+     */
+    static String hash(String code) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
+            byte[] hashBytes = digest.digest(code.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(HASH_ALGORITHM + " algorithm not available", e);
+        }
+    }
+
+    /**
+     * Verifies a submitted OTP code against a previously stored hash in constant time.
+     * <p>
+     * Hashes {@code submittedCode} and compares the resulting raw digest bytes against
+     * those decoded from {@code storedHash} using {@link MessageDigest#isEqual}, which
+     * runs in constant time to prevent timing-based side-channel attacks.
+     * </p>
+     *
+     * @param submittedCode the raw OTP code entered by the user (must not be {@code null})
+     * @param storedHash    the hex-encoded hash previously stored in the auth session (must not be {@code null})
+     * @return {@code true} if the submitted code matches the stored hash, {@code false} otherwise
+     * @throws IllegalStateException if {@value #HASH_ALGORITHM} is unexpectedly unavailable
+     */
+    static boolean matches(String submittedCode, String storedHash) {
+        byte[] submittedBytes = digestBytes(submittedCode);
+        byte[] storedBytes = HexFormat.of().parseHex(storedHash);
+        return MessageDigest.isEqual(submittedBytes, storedBytes);
+    }
+
+    private static byte[] digestBytes(String code) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
+            return digest.digest(code.getBytes(StandardCharsets.UTF_8));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(HASH_ALGORITHM + " algorithm not available", e);
+        }
+    }
+}

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/OtpHashUtils.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/OtpHashUtils.java
@@ -39,13 +39,7 @@ final class OtpHashUtils {
      * @throws IllegalStateException if {@value #HASH_ALGORITHM} is unexpectedly unavailable
      */
     static String hash(String code) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
-            byte[] hashBytes = digest.digest(code.getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hashBytes);
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException(HASH_ALGORITHM + " algorithm not available", e);
-        }
+        return HexFormat.of().formatHex(digestBytes(code));
     }
 
     /**

--- a/src/test/java/com/mesutpiskin/keycloak/auth/email/OtpHashUtilsTest.java
+++ b/src/test/java/com/mesutpiskin/keycloak/auth/email/OtpHashUtilsTest.java
@@ -1,0 +1,42 @@
+package com.mesutpiskin.keycloak.auth.email;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("OtpHashUtils Tests")
+class OtpHashUtilsTest {
+
+    @Test
+    @DisplayName("Same input always produces the same hash")
+    void testDeterministic() {
+        assertEquals(OtpHashUtils.hash("123456"), OtpHashUtils.hash("123456"));
+    }
+
+    @Test
+    @DisplayName("Different inputs produce different hashes")
+    void testCollisionResistance() {
+        assertNotEquals(OtpHashUtils.hash("123456"), OtpHashUtils.hash("654321"));
+    }
+
+    @Test
+    @DisplayName("Hash is never equal to the raw code")
+    void testHashDoesNotLeakRawCode() {
+        String code = "123456";
+        assertNotEquals(code, OtpHashUtils.hash(code));
+    }
+
+    @Test
+    @DisplayName("matches returns true for correct code against its stored hash")
+    void testMatchesCorrectCode() {
+        String code = "123456";
+        assertTrue(OtpHashUtils.matches(code, OtpHashUtils.hash(code)));
+    }
+
+    @Test
+    @DisplayName("matches returns false for wrong code against stored hash")
+    void testMatchesWrongCode() {
+        assertFalse(OtpHashUtils.matches("654321", OtpHashUtils.hash("123456")));
+    }
+}


### PR DESCRIPTION
## Problem

Two related security issues were identified in `EmailAuthenticatorForm`:

1. **Timing attack** — OTP validation was using `String.equals()`, which short-circuits on the first mismatch and leaks information about the OTP content through measurable response time differences.
2. **Plain-text OTP in session** — the generated code was stored as-is in `authNote`, meaning anyone with access to session internals (logs, memory dumps, Keycloak admin API) could read a live code.

`EmailAuthenticatorRequiredAction` already uses `MessageDigest.isEqual()` correctly — this PR brings `EmailAuthenticatorForm` in line with the same approach, and adds hashing on top to address the storage issue.

## Changes

### 1. OTP stored as SHA-256 hash

The raw code is hashed before being written to the session note. Validation hashes the submitted code and compares digests — the plaintext never touches storage.

```java
// Before
session.setAuthNote(EmailConstants.CODE, code);
// After
session.setAuthNote(EmailConstants.CODE, OtpHashUtils.hash(code));
```

### 2. Constant-time comparison on raw digest bytes

Comparison is now done on the 32-byte raw digest arrays via `MessageDigest.isEqual()`, which is guaranteed to run in constant time — as opposed to the previous `String.equals()` on plain OTP codes which short-circuits on first mismatch.

```java
// Before
if (codeContext.submittedCode().equals(codeContext.storedCode())) { ... }
// After
if (OtpHashUtils.matches(codeContext.submittedCode(), codeContext.storedCode())) { ... }
```

## Why `MessageDigest.isEqual()`?

`MessageDigest.isEqual()` is the standard Java idiom for constant-time byte array comparison. It guarantees that the comparison takes the same amount of time regardless of how many characters match, preventing timing side-channel attacks.

## Testing
- [x] OTP accepted when correct code is submitted
- [x] OTP rejected when wrong code is submitted
- [x] Stored auth note never contains the raw OTP
- [x] `OtpHashUtils` unit-tested in isolation (hash determinism, constant-time match/no-match)