### PR TITLE
Skip lib brute force counter when Keycloak BFP is active

### DIFF
--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -283,26 +283,31 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
 
         context.getEvent().user(user).error(Errors.INVALID_USER_CREDENTIALS);
 
-        AuthenticationSessionModel session = context.getAuthenticationSession();
-        int attempts = incrementAttempts(session);
-
-        AuthenticatorConfigModel config = context.getAuthenticatorConfig();
-        Map<String, String> configValues = config != null && config.getConfig() != null
-                ? config.getConfig()
-                : Map.of();
-        int maxAttempts = resolvePositiveInt(configValues, EmailConstants.MAX_ATTEMPTS,
-                EmailConstants.DEFAULT_MAX_ATTEMPTS);
-
-        if (attempts >= maxAttempts) {
-            resetEmailCode(context);
-            LoginFormsProvider form = prepareForm(context, null);
-            form.setAttribute("maxAttemptsReached", true);
-            applyFormMessage(form, "email-authenticator-too-many-attempts", EmailConstants.CODE);
-            Response challengeResponse = form.createForm("email-code-form.ftl");
-            context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
-        } else {
+        if (context.getRealm().isBruteForceProtected()) {
             Response challengeResponse = challenge(context, Messages.INVALID_ACCESS_CODE, EmailConstants.CODE);
             context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
+        } else {
+            AuthenticationSessionModel session = context.getAuthenticationSession();
+            int attempts = incrementAttempts(session);
+
+            AuthenticatorConfigModel config = context.getAuthenticatorConfig();
+            Map<String, String> configValues = config != null && config.getConfig() != null
+                    ? config.getConfig()
+                    : Map.of();
+            int maxAttempts = resolvePositiveInt(configValues, EmailConstants.MAX_ATTEMPTS,
+                    EmailConstants.DEFAULT_MAX_ATTEMPTS);
+
+            if (attempts >= maxAttempts) {
+                resetEmailCode(context);
+                LoginFormsProvider form = prepareForm(context, null);
+                form.setAttribute("maxAttemptsReached", true);
+                applyFormMessage(form, "email-authenticator-too-many-attempts", EmailConstants.CODE);
+                Response challengeResponse = form.createForm("email-code-form.ftl");
+                context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
+            } else {
+                Response challengeResponse = challenge(context, Messages.INVALID_ACCESS_CODE, EmailConstants.CODE);
+                context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, challengeResponse);
+            }
         }
         return false;
     }

--- a/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormTest.java
+++ b/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormTest.java
@@ -1,14 +1,27 @@
 package com.mesutpiskin.keycloak.auth.email;
 
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.events.EventBuilder;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.http.HttpRequest;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -111,6 +124,107 @@ class EmailAuthenticatorFormTest {
         // Expose protected method for testing
         public String testDisabledByBruteForceError() {
             return disabledByBruteForceError();
+        }
+    }
+
+    /**
+     * Bypasses enabledUser (requires full Keycloak infra) to isolate brute-force logic.
+     */
+    static class BfpTestableForm extends EmailAuthenticatorForm {
+        @Override
+        public boolean enabledUser(AuthenticationFlowContext context, UserModel user) {
+            return true;
+        }
+    }
+
+    @Nested
+    @DisplayName("Brute force protection — Keycloak BFP vs lib counter")
+    class BruteForceProtectionTests {
+
+        private BfpTestableForm form;
+        private AuthenticationFlowContext context;
+        private AuthenticationSessionModel session;
+        private RealmModel realm;
+        private UserModel user;
+        private LoginFormsProvider loginForm;
+
+        @BeforeEach
+        void setUp() {
+            form = new BfpTestableForm();
+            context = mock(AuthenticationFlowContext.class);
+            session = mock(AuthenticationSessionModel.class);
+            realm = mock(RealmModel.class);
+            user = mock(UserModel.class);
+            loginForm = mock(LoginFormsProvider.class);
+
+            when(context.getUser()).thenReturn(user);
+            when(context.getAuthenticationSession()).thenReturn(session);
+            when(context.getRealm()).thenReturn(realm);
+
+            HttpRequest httpRequest = mock(HttpRequest.class);
+            MultivaluedHashMap<String, String> formData = new MultivaluedHashMap<>();
+            formData.putSingle(EmailConstants.CODE, "000000"); // wrong code — stored is hash("123456")
+            when(context.getHttpRequest()).thenReturn(httpRequest);
+            when(httpRequest.getDecodedFormParameters()).thenReturn(formData);
+
+            when(session.getAuthNote(EmailConstants.CODE)).thenReturn(OtpHashUtils.hash("123456"));
+            when(session.getAuthNote(EmailConstants.CODE_TTL))
+                    .thenReturn(String.valueOf(System.currentTimeMillis() + 300_000));
+            when(session.getAuthNote(EmailConstants.CODE_RESEND_AVAILABLE_AFTER)).thenReturn(null);
+            when(session.getAuthNote("emailCodeAttempts")).thenReturn(null);
+
+            EventBuilder event = mock(EventBuilder.class);
+            when(context.getEvent()).thenReturn(event);
+            when(event.user(any(UserModel.class))).thenReturn(event);
+
+            AuthenticationExecutionModel execution = mock(AuthenticationExecutionModel.class);
+            when(context.getExecution()).thenReturn(execution);
+            when(execution.getId()).thenReturn("test-exec");
+            when(context.form()).thenReturn(loginForm);
+            when(loginForm.setExecution(anyString())).thenReturn(loginForm);
+            when(loginForm.setAttribute(anyString(), any())).thenReturn(loginForm);
+            when(loginForm.addError(any())).thenReturn(loginForm);
+            when(loginForm.createForm(anyString())).thenReturn(mock(Response.class));
+
+            AuthenticatorConfigModel config = mock(AuthenticatorConfigModel.class);
+            when(context.getAuthenticatorConfig()).thenReturn(config);
+            when(config.getConfig()).thenReturn(Map.of(EmailConstants.MAX_ATTEMPTS, "5"));
+        }
+
+        @Test
+        @DisplayName("Keycloak BFP actif — le compteur de la lib ne doit pas être incrémenté")
+        void testKeycloakBfpActive_doesNotIncrementAttempts() {
+            when(realm.isBruteForceProtected()).thenReturn(true);
+
+            form.action(context);
+
+            verify(session, never()).setAuthNote(eq("emailCodeAttempts"), anyString());
+            verify(context).failureChallenge(eq(AuthenticationFlowError.INVALID_CREDENTIALS), any());
+        }
+
+        @Test
+        @DisplayName("Keycloak BFP inactif — le compteur de la lib doit être incrémenté")
+        void testKeycloakBfpInactive_incrementsAttempts() {
+            when(realm.isBruteForceProtected()).thenReturn(false);
+
+            form.action(context);
+
+            verify(session).setAuthNote("emailCodeAttempts", "1");
+            verify(context).failureChallenge(eq(AuthenticationFlowError.INVALID_CREDENTIALS), any());
+        }
+
+        @Test
+        @DisplayName("Keycloak BFP inactif — seuil atteint : code réinitialisé et flag maxAttemptsReached positionné")
+        void testKeycloakBfpInactive_maxAttemptsReached_resetsCode() {
+            when(realm.isBruteForceProtected()).thenReturn(false);
+            when(session.getAuthNote("emailCodeAttempts")).thenReturn("4"); // prochain = 5 = max
+
+            form.action(context);
+
+            verify(session).setAuthNote("emailCodeAttempts", "5");
+            verify(session).removeAuthNote(EmailConstants.CODE);
+            verify(loginForm).setAttribute("maxAttemptsReached", true);
+            verify(context).failureChallenge(eq(AuthenticationFlowError.INVALID_CREDENTIALS), any());
         }
     }
 


### PR DESCRIPTION
  **Problem**

When Keycloak's built-in brute force protection is enabled on the realm, two independent systems were counting failed OTP attempts:
  - Keycloak's own BFP (persistent, realm-level, account lockout)
  - The lib's attempt counter (session-scoped, OTP reset on threshold)

_**This double-counting could lead to inconsistent behavior and confusing UX.**_

**Solution**

At OTP validation time, check realm.isBruteForceProtected():
  - Keycloak BFP active → skip the lib counter entirely, let Keycloak handle protection
  - Keycloak BFP inactive → lib counter and maxAttempts config behave as before

The resend cooldown is unaffected — it rate-limits email sending, not login attempts.

**Changes**

  - EmailAuthenticatorForm.java: conditional brute force logic in isValidCodeContext
  - EmailAuthenticatorFormTest.java: 3 new unit tests covering both branches and the max-attempts threshold case
