### PR TITLE
ci: add Maven Central publishing pipeline

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,5 +1,7 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+# Publishes artifacts to Maven Central and attaches JARs to GitHub Releases.
+# Triggered on every GitHub Release (type: released).
+# Requires secrets: CENTRAL_TOKEN_USERNAME, CENTRAL_TOKEN_PASSWORD,
+#                   GPG_SIGNING_KEY, GPG_SIGNING_KEY_PASSWORD
 
 name: Maven Package
 
@@ -16,30 +18,42 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          VERSIONS=$( curl -L -s https://api.github.com/repos/keycloak/keycloak/tags | jq -c 'sort_by(.name)[-11:-1] | [ .[] | .version=.name | {version}]' )
-          echo "::set-output name=matrix::{\"include\":$VERSIONS}"
+          VERSIONS=$( curl -L -s https://api.github.com/repos/keycloak/keycloak/releases \
+            | jq -c '[.[] | select(.prerelease == false and .draft == false)] | sort_by(.name)[-10:] | [ .[] | .version=.name | {version}]' )
+          echo "matrix={\"include\":$VERSIONS}" >> $GITHUB_OUTPUT
 
   build:
     needs: kc-version-matrix
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix: ${{fromJson(needs.kc-version-matrix.outputs.matrix)}}
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
         with:
-          java-version: '11'
+          fetch-depth: 0
+      - name: Set up Maven Central Repository
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
-      - name: Set version
-        run: mvn versions:set -DnewVersion=$(git describe --tags)-KC${{ matrix.version }}
-      - name: Build with Maven
-        run: mvn -Dkeycloak.version=${{ matrix.version }} -B package --file pom.xml
-      - name: Release
-        uses: softprops/action-gh-release@v1
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Set version corresponding to Keycloak version
+        run: mvn versions:set -DnewVersion=$(git describe --tags | sed 's/^v//')-KC${{ matrix.version }}
+      - name: Build and publish to Maven Central
+        run: mvn -Dkeycloak.version=${{ matrix.version }} -B deploy --file pom.xml -P release --batch-mode
+        env:
+          MAVEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_KEY_PASSWORD }}
+      - name: Attach artifact to release
+        uses: softprops/action-gh-release@v2
         with:
           files: target/keycloak-2fa-email-authenticator*
-          name: Keycloak 2FA Email Authenticator v${{ github.event.release.tag_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,32 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
 
+    <name>Keycloak 2FA email authenticator</name>
+    <description>A Keycloak authenticator for 2FA via email OTP</description>
+    <url>https://github.com/mesutpiskin/keycloak-2fa-email-authenticator</url>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Mesut Pişkin</name>
+            <email>mesutpiskin@outlook.com</email>
+            <organization>mesutpiskin</organization>
+            <organizationUrl>https://github.com/mesutpiskin</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/mesutpiskin/keycloak-2fa-email-authenticator.git</connection>
+        <developerConnection>scm:git:ssh://github.com:mesutpiskin/keycloak-2fa-email-authenticator.git</developerConnection>
+        <url>https://github.com/mesutpiskin/keycloak-2fa-email-authenticator/tree/main</url>
+    </scm>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
@@ -117,4 +143,77 @@
         </plugins>
         <finalName>${project.artifactId}-v${project.version}</finalName>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.10.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <tokenAuth>true</tokenAuth>
+                            <autoPublish>true</autoPublish>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadoc</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <stylesheet>java</stylesheet>
+                            <doclint>none</doclint>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>


### PR DESCRIPTION
## Summary
- Adds required POM metadata (`name`, `description`, `url`, `licenses`, `developers`, `scm`) — these are mandatory for Maven Central
- Adds `release` Maven profile with `central-publishing-maven-plugin 0.10.0`, `maven-source-plugin`, `maven-javadoc-plugin`, `maven-gpg-plugin`
- Rewrites `maven-publish.yml` from scratch, fixing several bugs in the original version:
  - Upgrades to `actions/checkout@v4` and `actions/setup-java@v4`
  - Java 11 → Java 21
  - Fixes deprecated `::set-output` → `$GITHUB_OUTPUT`
  - Fixes `fail-fast: false` which was wrongly placed under `kc-version-matrix.outputs` (silently ignored) → moved to `build.strategy`
  - Strips `v` prefix from `git describe --tags` before setting Maven version (Maven versions must not start with `v`)
  - Switches Keycloak version source from `/tags` API to `/releases` API, filters out pre-releases/drafts
  - Adds actual Maven Central deploy step (`mvn deploy -P release`) with GPG and token auth
  - Updates `softprops/action-gh-release` v1 → v2

## Required manual setup (before first release)
Add these four secrets in **Settings → Secrets → Actions**:

| Secret | Where to get it |
|--------|----------------|
| `CENTRAL_TOKEN_USERNAME` | https://central.sonatype.com/account → User Token |
| `CENTRAL_TOKEN_PASSWORD` | same page |
| `GPG_SIGNING_KEY` | `gpg --export-secret-keys --armor <KEY_ID>` |
| `GPG_SIGNING_KEY_PASSWORD` | passphrase for that key |

## Test plan
- [x] `mvn clean test` — 37/37 tests pass locally
- [x] `mvn clean package -P release -Dgpg.skip=true` — BUILD SUCCESS (sources + javadoc JARs generated)
- [x] YAML linting passes (`python3 -c "import yaml; yaml.safe_load(...)"`)