### PR TITLE
fix: KC 26.5.x cross-version compat + central-publishing-maven-plugin 0.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,6 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
-                            <tokenAuth>true</tokenAuth>
                             <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/ConditionalEmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/ConditionalEmailAuthenticatorForm.java
@@ -20,7 +20,6 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 
 import jakarta.ws.rs.core.MultivaluedMap;
-import org.keycloak.utils.KeycloakSessionUtil;
 
 /**
  * Conditional email authenticator that decides whether to enforce OTP based on
@@ -279,7 +278,7 @@ public class ConditionalEmailAuthenticatorForm extends EmailAuthenticatorForm {
             return false;
         }
         
-        RoleModel role = getRoleFromString(KeycloakSessionUtil.getKeycloakSession(), realm, roleName);
+        RoleModel role = getRoleFromString(realm, roleName);
         if (role != null) {
             return user.hasRole(role);
         }


### PR DESCRIPTION
## Root cause analysis

Maven Package workflow failed for all 10 KC versions. Two separate bugs found:

### Bug 1 — KC 26.5.x compilation failure
`ConditionalEmailAuthenticatorForm.java:282` calls `getRoleFromString(session, realm, roleName)` (3-arg), but this overload was only **added in KC 26.6.0**. KC 26.5.x only has `getRoleFromString(realm, roleName)` (2-arg).

**Fix:** Use the 2-arg version — it compiles and works identically on both KC 26.5.x and 26.6.x.

### Bug 2 — KC 26.6.1 Maven Central deploy failure
`central-publishing-maven-plugin 0.10.0` removed the `tokenAuth` configuration parameter. Having it in `pom.xml` caused a deployment failure (`Parameter 'tokenAuth' is unknown`).

**Fix:** Remove `<tokenAuth>true</tokenAuth>` from plugin config — token auth is now the default in 0.10.0.

## Verification

```
mvn clean test                          → 37/37 PASS
mvn clean test -Dkeycloak.version=26.5.3 → 37/37 PASS
```

## Next step
After merging, delete and re-create the `v26.3.0` release to re-trigger the workflow.