### PR TITLE
fix: change groupId to io.github.mesutpiskin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <artifactId>keycloak-2fa-email-authenticator</artifactId>
-    <groupId>com.mesutpiskin.keycloak</groupId>
+    <groupId>io.github.mesutpiskin</groupId>
     <version>26.3.0</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>


### PR DESCRIPTION
## Problem
`com.mesutpiskin.keycloak` namespace is not allowed on Maven Central — requires DNS verification of `mesutpiskin.com` domain.

## Fix
Change groupId to `io.github.mesutpiskin` which is claimable via GitHub account.

## ⚠️ Action required before merge
Claim the namespace at **https://central.sonatype.com**:
1. Log in → **Namespaces** → **Add Namespace**
2. Enter `io.github.mesutpiskin`
3. Verify via GitHub (it checks that you own the `mesutpiskin` GitHub account)

Once verified, merge this PR and re-trigger the release.

## New Maven coordinate
```xml
<dependency>
  <groupId>io.github.mesutpiskin</groupId>
  <artifactId>keycloak-2fa-email-authenticator</artifactId>
  <version>26.3.0-KC26.x.x</version>
</dependency>
```