### PR TITLE
fix: skip Maven Central publish when version already exists

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -49,7 +49,15 @@ jobs:
       - name: Set version corresponding to Keycloak version
         run: mvn versions:set -DnewVersion=$(git describe --tags | sed 's/^v//')-KC${{ matrix.version }}
       - name: Build and publish to Maven Central
-        run: mvn -Dkeycloak.version=${{ matrix.version }} -B deploy --file pom.xml -P release --batch-mode
+        run: |
+          output=$(mvn -Dkeycloak.version=${{ matrix.version }} -B deploy --file pom.xml -P release --batch-mode 2>&1)
+          mvn_exit=$?
+          echo "$output"
+          if echo "$output" | grep -q "already exists"; then
+            echo "Version already exists on Maven Central — skipping."
+            exit 0
+          fi
+          exit $mvn_exit
         env:
           MAVEN_USERNAME: ${{ secrets.CENTRAL_TOKEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.CENTRAL_TOKEN_PASSWORD }}


### PR DESCRIPTION
Maven Central is immutable — same version cannot be republished. Captures mvn exit code separately from output, skips gracefully on 'already exists', fails on any other error.