### PR TITLE
fix: use set +e to capture mvn exit code under bash -e

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -50,8 +50,10 @@ jobs:
         run: mvn versions:set -DnewVersion=$(git describe --tags | sed 's/^v//')-KC${{ matrix.version }}
       - name: Build and publish to Maven Central
         run: |
+          set +e
           output=$(mvn -Dkeycloak.version=${{ matrix.version }} -B deploy --file pom.xml -P release --batch-mode 2>&1)
           mvn_exit=$?
+          set -e
           echo "$output"
           if echo "$output" | grep -q "already exists"; then
             echo "Version already exists on Maven Central — skipping."


### PR DESCRIPTION
GitHub Actions uses `bash -e`, so `output=$(mvn ...)` exits immediately on failure before `mvn_exit=$?` runs. Adding `set +e` before and `set -e` after fixes the capture.