### PR TITLE
fix: isConfiguredFor handles skipSetup users with email - resolves #106 #112 #100 #50 #98 #108

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <artifactId>keycloak-2fa-email-authenticator</artifactId>
     <groupId>io.github.mesutpiskin</groupId>
-    <version>26.3.0</version>
+    <version>26.3.1</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
 

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorCredentialProvider.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorCredentialProvider.java
@@ -7,6 +7,7 @@ import org.keycloak.credential.CredentialModel;
 import org.keycloak.credential.CredentialProvider;
 import org.keycloak.credential.CredentialTypeMetadata;
 import org.keycloak.credential.CredentialTypeMetadataContext;
+import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -36,10 +37,36 @@ public class EmailAuthenticatorCredentialProvider
         if (!supportsCredentialType(credentialType)) {
             return false;
         }
-        return user.credentialManager()
+        if (user.credentialManager()
                 .getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID)
                 .findAny()
-                .isPresent();
+                .isPresent()) {
+            return true;
+        }
+        // When skip-setup is enabled, users with an email are considered configured without
+        // explicit enrollment. This enables "Try Another Way" selection and admin-enforced 2FA.
+        return isSkipSetupEnabled(realm) && user.getEmail() != null && !user.getEmail().isBlank();
+    }
+
+    private boolean isSkipSetupEnabled(RealmModel realm) {
+        return realm.getAuthenticationFlowsStream()
+                .flatMap(flow -> realm.getAuthenticationExecutionsStream(flow.getId()))
+                .filter(exec -> EmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator())
+                        || ConditionalEmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator()))
+                .map(exec -> {
+                    String configId = exec.getAuthenticatorConfig();
+                    if (configId != null) {
+                        AuthenticatorConfigModel config = realm.getAuthenticatorConfigById(configId);
+                        if (config != null && config.getConfig() != null) {
+                            return Boolean.parseBoolean(
+                                    config.getConfig().getOrDefault(EmailConstants.SKIP_SETUP,
+                                            String.valueOf(EmailConstants.DEFAULT_SKIP_SETUP)));
+                        }
+                    }
+                    return EmailConstants.DEFAULT_SKIP_SETUP;
+                })
+                .findFirst()
+                .orElse(EmailConstants.DEFAULT_SKIP_SETUP);
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -391,7 +391,8 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
 
     @Override
     public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
-        if (getCredentialProvider(session).isConfiguredFor(realm, user, getType(session))) {
+        EmailAuthenticatorCredentialProvider provider = getCredentialProvider(session);
+        if (provider != null && provider.isConfiguredFor(realm, user, getType(session))) {
             return true;
         }
         if (isSkipSetupEnabled(realm)) {
@@ -403,7 +404,8 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
     private boolean isSkipSetupEnabled(RealmModel realm) {
         return realm.getAuthenticationFlowsStream()
                 .flatMap(flow -> realm.getAuthenticationExecutionsStream(flow.getId()))
-                .filter(exec -> EmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator()))
+                .filter(exec -> EmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator())
+                        || ConditionalEmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator()))
                 .map(exec -> {
                     String configId = exec.getAuthenticatorConfig();
                     if (configId != null) {

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorRequiredAction.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorRequiredAction.java
@@ -47,28 +47,9 @@ public class EmailAuthenticatorRequiredAction implements RequiredActionProvider,
 
     @Override
     public void evaluateTriggers(RequiredActionContext context) {
-        // When "Skip Setup" is enabled, users with an email are considered configured by default.
-        // Since this authenticator implements CredentialValidator, Keycloak uses the credential store
-        // directly and bypasses configuredFor() — so we must create the credential here to make the
-        // authenticator visible in the flow.
-        Map<String, String> config = findAuthenticatorConfig(context);
-        if (!Boolean.parseBoolean(config.getOrDefault(EmailConstants.SKIP_SETUP, String.valueOf(EmailConstants.DEFAULT_SKIP_SETUP)))) {
-            return;
-        }
-        UserModel user = context.getUser();
-        if (user.getEmail() == null || user.getEmail().isBlank()) {
-            return;
-        }
-        boolean hasCredential = user.credentialManager()
-                .getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID)
-                .findAny().isPresent();
-        if (hasCredential) {
-            return;
-        }
-        EmailAuthenticatorCredentialModel credential = EmailAuthenticatorCredentialModel.create();
-        credential.setUserLabel(user.getEmail());
-        user.credentialManager().createStoredCredential(credential);
-        logger.infof("Auto-enrolled user %s for Email 2FA (skipSetup enabled)", user.getUsername());
+        // isConfiguredFor() in EmailAuthenticatorCredentialProvider handles the skipSetup case
+        // (returns true when user has email and skipSetup is enabled), so auto-enrollment
+        // here is not needed and would create unwanted credentials in account management.
     }
 
     @Override
@@ -280,7 +261,8 @@ public class EmailAuthenticatorRequiredAction implements RequiredActionProvider,
 
         return realm.getAuthenticationFlowsStream()
                 .flatMap(flow -> realm.getAuthenticationExecutionsStream(flow.getId()))
-                .filter(exec -> EmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator()))
+                .filter(exec -> EmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator())
+                        || ConditionalEmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator()))
                 .map(exec -> {
                     String configId = exec.getAuthenticatorConfig();
                     if (configId != null) {

--- a/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorCredentialProviderTest.java
+++ b/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorCredentialProviderTest.java
@@ -1,16 +1,23 @@
 package com.mesutpiskin.keycloak.auth.email;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticationFlowModel;
+import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.SubjectCredentialManager;
 import org.keycloak.models.UserModel;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +36,7 @@ class EmailAuthenticatorCredentialProviderTest {
         user = mock(UserModel.class);
         credentialManager = mock(SubjectCredentialManager.class);
         when(user.credentialManager()).thenReturn(credentialManager);
+        when(realm.getAuthenticationFlowsStream()).thenReturn(Stream.empty());
         provider = new EmailAuthenticatorCredentialProvider(session);
     }
 
@@ -44,13 +52,13 @@ class EmailAuthenticatorCredentialProviderTest {
     }
 
     @Test
-    void testIsConfiguredFor_WithNoStoredCredential() {
+    void testIsConfiguredFor_WithNoStoredCredential_NoSkipSetup() {
         when(credentialManager.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
                 .thenReturn(Stream.empty());
 
         boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
 
-        assertFalse(result, "Should not be configured when no stored credential exists");
+        assertFalse(result, "Should not be configured when no stored credential and no skip-setup config");
     }
 
     @Test
@@ -58,5 +66,113 @@ class EmailAuthenticatorCredentialProviderTest {
         boolean result = provider.isConfiguredFor(realm, user, "wrong-type");
 
         assertFalse(result, "Should return false for unsupported credential type");
+    }
+
+    @Nested
+    @DisplayName("Skip-setup fallback for users with email")
+    class SkipSetupTests {
+
+        private AuthenticationFlowModel flow;
+        private AuthenticationExecutionModel execution;
+        private AuthenticatorConfigModel config;
+
+        @BeforeEach
+        void setUp() {
+            when(credentialManager.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
+                    .thenReturn(Stream.empty());
+
+            flow = mock(AuthenticationFlowModel.class);
+            execution = mock(AuthenticationExecutionModel.class);
+            config = mock(AuthenticatorConfigModel.class);
+
+            when(flow.getId()).thenReturn("flow-1");
+            when(realm.getAuthenticationFlowsStream()).thenReturn(Stream.of(flow));
+            when(realm.getAuthenticationExecutionsStream("flow-1")).thenReturn(Stream.of(execution));
+            when(execution.getAuthenticator()).thenReturn(EmailAuthenticatorFormFactory.PROVIDER_ID);
+            when(execution.getAuthenticatorConfig()).thenReturn("config-1");
+            when(realm.getAuthenticatorConfigById("config-1")).thenReturn(config);
+        }
+
+        @Test
+        @DisplayName("Returns true when skipSetup=true and user has email")
+        void testSkipSetup_true_withEmail() {
+            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "true"));
+            when(user.getEmail()).thenReturn("user@example.com");
+
+            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
+
+            assertTrue(result, "Should be configured when skipSetup=true and user has email");
+        }
+
+        @Test
+        @DisplayName("Returns false when skipSetup=false and no stored credential")
+        void testSkipSetup_false_noCredential() {
+            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "false"));
+            when(user.getEmail()).thenReturn("user@example.com");
+
+            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
+
+            assertFalse(result, "Should not be configured when skipSetup=false and no stored credential");
+        }
+
+        @Test
+        @DisplayName("Returns false when skipSetup=true but user has no email")
+        void testSkipSetup_true_noEmail() {
+            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "true"));
+            when(user.getEmail()).thenReturn(null);
+
+            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
+
+            assertFalse(result, "Should not be configured when user has no email even with skipSetup=true");
+        }
+
+        @Test
+        @DisplayName("Returns false when skipSetup=true but user has blank email")
+        void testSkipSetup_true_blankEmail() {
+            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "true"));
+            when(user.getEmail()).thenReturn("   ");
+
+            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
+
+            assertFalse(result, "Should not be configured when user has blank email even with skipSetup=true");
+        }
+
+        @Test
+        @DisplayName("Returns true when conditional authenticator has skipSetup=true and user has email")
+        void testConditionalAuthenticator_skipSetup_true_withEmail() {
+            when(execution.getAuthenticator()).thenReturn(ConditionalEmailAuthenticatorFormFactory.PROVIDER_ID);
+            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "true"));
+            when(user.getEmail()).thenReturn("user@example.com");
+
+            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
+
+            assertTrue(result, "Should be configured for conditional authenticator with skipSetup=true and email");
+        }
+
+        @Test
+        @DisplayName("Returns true with default skipSetup (true) when no config is set")
+        void testDefaultSkipSetup_withEmail() {
+            when(execution.getAuthenticatorConfig()).thenReturn(null);
+            when(user.getEmail()).thenReturn("user@example.com");
+
+            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
+
+            assertTrue(result, "Should be configured by default (skipSetup defaults to true) when user has email");
+        }
+
+        @Test
+        @DisplayName("Stored credential takes precedence over skipSetup=false")
+        void testStoredCredential_overridesSkipSetupFalse() {
+            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "false"));
+            when(user.getEmail()).thenReturn("user@example.com");
+
+            var credential = new EmailAuthenticatorCredentialModel();
+            when(credentialManager.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
+                    .thenReturn(Stream.of(credential));
+
+            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
+
+            assertTrue(result, "Should be configured when stored credential exists, regardless of skipSetup");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **`EmailAuthenticatorCredentialProvider.isConfiguredFor()`** now falls back to checking \`skipSetup\` config + user email when no stored credential exists. Users with an email address and \`skipSetup=true\` (the default) are considered configured without needing explicit enrollment.
- **Both provider IDs searched**: \`isSkipSetupEnabled()\` in credential provider, authenticator form, and required action now searches both \`email-authenticator\` and \`email-conditional-authenticator\` executions, so conditional flows are handled correctly.
- **Null-safety in \`configuredFor()\`**: Added null-check for \`getCredentialProvider(session)\` to prevent NPE.
- **Removed auto-enrollment from \`evaluateTriggers()\`**: No longer auto-creates stored credentials at login since \`isConfiguredFor()\` handles the skipSetup case directly — this prevents the "always shown as configured" issue (#108).
- **Version bumped to 26.3.1**.

## Issues Fixed

| # | Issue | Root Cause | Fix |
|---|-------|-----------|-----|
| #106 | "credential setup required" on fresh install | \`isConfiguredFor()\` returned false (no stored credential) | Now returns true for skipSetup+email users |
| #100 | AuthenticationFlowException: empty alternative selection | Same root cause | Same fix |
| #112 | Setup screen shown for admin-configured users | \`isConfiguredFor()\` returned false before \`evaluateTriggers()\` ran | Same fix |
| #50 | "Try Another Way" not showing email OTP | \`isConfiguredFor()\` returned false → not listed as alternative | Same fix |
| #98 | "Try Another Way" option missing | Same as #50 | Same fix |
| #108 | Always shown as configured in account UI | \`evaluateTriggers()\` auto-created credentials on every login | Removed auto-enrollment |

## Test plan
- [x] All 44 existing tests pass
- [x] 7 new unit tests added for skip-setup scenarios in \`EmailAuthenticatorCredentialProviderTest\`
- [x] Tests cover: skipSetup=true with email, skipSetup=false without credential, no email, blank email, conditional authenticator variant, default config, stored credential takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)