### PR TITLE
Update Docusaurus configuration and README for pnpm and links

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,11 @@ on:
       - main
     paths:
       - "website/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "website/**"
   workflow_dispatch:
 
 permissions:
@@ -14,7 +19,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -46,14 +51,17 @@ jobs:
         run: pnpm build
 
       - name: Setup Pages
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: website/build
 
   deploy:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: build
     environment:

--- a/website/README.md
+++ b/website/README.md
@@ -5,13 +5,13 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 ## Installation
 
 ```bash
-yarn
+pnpm install
 ```
 
 ## Local Development
 
 ```bash
-yarn start
+pnpm start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -19,7 +19,7 @@ This command starts a local development server and opens up a browser window. Mo
 ## Build
 
 ```bash
-yarn build
+pnpm build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -29,13 +29,13 @@ This command generates static content into the `build` directory and can be serv
 Using SSH:
 
 ```bash
-USE_SSH=true yarn deploy
+USE_SSH=true pnpm deploy
 ```
 
 Not using SSH:
 
 ```bash
-GIT_USER=<Your GitHub username> yarn deploy
+GIT_USER=<Your GitHub username> pnpm deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -15,6 +15,7 @@ const config: Config = {
     mermaid: true,
     hooks: {
       onBrokenMarkdownLinks: "throw",
+      onBrokenMarkdownImages: "throw",
     },
   },
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -20,7 +20,7 @@ const config: Config = {
   url: "https://mesutpiskin.github.io",
   baseUrl: "/keycloak-2fa-email-authenticator/",
 
-  organizationName: "io.github.mesutpiskin",
+  organizationName: "mesutpiskin",
   projectName: "keycloak-2fa-email-authenticator",
   trailingSlash: false,
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -24,7 +24,9 @@ const config: Config = {
   projectName: "keycloak-2fa-email-authenticator",
   trailingSlash: false,
 
-  onBrokenLinks: "warn",
+  onBrokenLinks: "throw",
+  onBrokenMarkdownLinks: "throw",
+  onBrokenAnchors: "warn",
 
   i18n: {
     defaultLocale: "en",

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -13,6 +13,9 @@ const config: Config = {
 
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: "throw",
+    },
   },
 
   themes: ["@docusaurus/theme-mermaid"],
@@ -25,7 +28,6 @@ const config: Config = {
   trailingSlash: false,
 
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "throw",
   onBrokenAnchors: "warn",
 
   i18n: {


### PR DESCRIPTION
This pull request updates the Docusaurus website configuration and documentation to improve reliability and align with current tooling.

Follow-up to #131 , addressing the three points raised by @mesutpiskin after merge.

**Documentation and Tooling Updates:**

* Updated all `website/README.md` instructions to use `pnpm` instead of `yarn` for installing dependencies, starting the dev server, building, and deploying the site. 

**Configuration Improvements:**

* Changed `onBrokenLinks` and added `onBrokenMarkdownLinks`/`onBrokenMarkdownImages` in `docusaurus.config.ts` to `"throw"` so the build will fail on broken links or images in both markdown and general site content, making the site more robust. Also set `onBrokenAnchors` to `"warn"`.
* Updated the `organizationName` in `docusaurus.config.ts` from `"io.github.mesutpiskin"` to `"mesutpiskin"` to match the correct GitHub organization/user.

**CI Improvements**

- **`.github/workflows/deploy-docs.yml`** — run the build job on pull requests targeting `main` (catching broken links before merge); upload artifact and deploy steps remain restricted to pushes on `main` and `workflow_dispatch` via `if: github.event_name != 'pull_request'`