### PR TITLE
feat: add masked email display on OTP form

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Full documentation — installation, configuration, template customization, and 
 
 **https://mesutpiskin.github.io/keycloak-2fa-email-authenticator/**
 
+## Highlights
+
+- Email OTP login for Keycloak browser flows
+- Configurable code length, TTL, resend cooldown, and max attempts
+- Optional **masked email display** on the OTP form for better UX after the code is sent
+- Multiple email delivery backends: Keycloak SMTP, SendGrid, AWS SES, and Mailgun
+
 ## Quick Start
 
 The easiest way to get the JAR is via Maven Central. Use the version matching your Keycloak installation:

--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -240,6 +240,10 @@ Click **⚙️ (Settings)** icon on "Email OTP" row:
 - **Time-to-live:** 300 (5 minutes)
 - **Simulation mode:** false (for real emails)
 - **Resend cooldown:** 30 (seconds)
+- **Max code attempts:** 5
+- **Show Masked Email on OTP Form:** false by default
+
+If you enable **Show Masked Email on OTP Form**, the login form shows a server-generated masked value such as `u***e@example.com` after the OTP is sent. This does not rely on `${user.email!}` being available in the Freemarker template context.
 
 ---
 

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -316,8 +316,9 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
         AuthenticationSessionModel session = context.getAuthenticationSession();
         LoginFormsProvider form = context.form().setExecution(context.getExecution().getId());
         Long secondsToExpose = remainingSeconds != null ? remainingSeconds : getRemainingSeconds(session);
-        if (secondsToExpose != null && secondsToExpose > 0L)
+        if (secondsToExpose != null && secondsToExpose > 0L) {
             form.setAttribute("resendAvailableInSeconds", secondsToExpose);
+        }
 
         AuthenticatorConfigModel config = context.getAuthenticatorConfig();
         Map<String, String> configValues = config != null && config.getConfig() != null
@@ -326,7 +327,45 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
         int codeLength = resolvePositiveInt(configValues, EmailConstants.CODE_LENGTH, EmailConstants.DEFAULT_LENGTH);
         form.setAttribute("codeLength", codeLength);
 
+        if (isMaskedEmailVisible(configValues)) {
+            String maskedEmail = maskEmailAddress(context.getUser());
+            if (maskedEmail != null) {
+                form.setAttribute("maskedEmail", maskedEmail);
+            }
+        }
+
         return form;
+    }
+
+    private boolean isMaskedEmailVisible(Map<String, String> configValues) {
+        return Boolean.parseBoolean(configValues.getOrDefault(
+                EmailConstants.SHOW_MASKED_EMAIL_ON_OTP_FORM,
+                String.valueOf(EmailConstants.DEFAULT_SHOW_MASKED_EMAIL_ON_OTP_FORM)));
+    }
+
+    private String maskEmailAddress(UserModel user) {
+        if (user == null) {
+            return null;
+        }
+
+        String email = user.getEmail();
+        if (email == null || email.isBlank()) {
+            return null;
+        }
+
+        int atIndex = email.indexOf('@');
+        if (atIndex <= 0 || atIndex == email.length() - 1) {
+            return email;
+        }
+
+        String localPart = email.substring(0, atIndex);
+        String domainPart = email.substring(atIndex);
+
+        if (localPart.length() <= 2) {
+            return localPart.charAt(0) + "***" + domainPart;
+        }
+
+        return localPart.charAt(0) + "***" + localPart.charAt(localPart.length() - 1) + domainPart;
     }
 
     private Long getRemainingSeconds(AuthenticationSessionModel session) {

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
@@ -125,6 +125,9 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
                 new ProviderConfigProperty(EmailConstants.MAX_ATTEMPTS, "Max Code Attempts",
                         "The maximum number of invalid code attempts before the code is invalidated and a new one must be requested.",
                         ProviderConfigProperty.STRING_TYPE, String.valueOf(EmailConstants.DEFAULT_MAX_ATTEMPTS)),
+                new ProviderConfigProperty(EmailConstants.SHOW_MASKED_EMAIL_ON_OTP_FORM, "Show Masked Email on OTP Form",
+                        "If enabled, displays a masked version of the user's email address on the OTP entry form after the code is sent.",
+                        ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_SHOW_MASKED_EMAIL_ON_OTP_FORM)),
                 new ProviderConfigProperty(EmailConstants.SKIP_SETUP, "Skip Setup",
                         "When enabled, users with an email address are considered configured without needing to complete the enrollment flow. Useful for admin-enforced 2FA.",
                         ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_SKIP_SETUP)));

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
@@ -189,6 +189,18 @@ public final class EmailConstants {
 	 */
 	public static final String DEFAULT_MAILGUN_REGION = "US";
 
+
+	/**
+	 * Configuration key for showing a masked version of the user's email address
+	 * on the OTP form.
+	 */
+	public static final String SHOW_MASKED_EMAIL_ON_OTP_FORM = "showMaskedEmailOnOtpForm";
+
+	/**
+	 * Default setting for showing masked email on the OTP form.
+	 */
+	public static final boolean DEFAULT_SHOW_MASKED_EMAIL_ON_OTP_FORM = false;
+
 	/**
 	 * Configuration key for skipping the setup required action.
 	 * When enabled, users with an email address are considered configured

--- a/src/main/resources/theme-resources/templates/email-code-form.ftl
+++ b/src/main/resources/theme-resources/templates/email-code-form.ftl
@@ -9,7 +9,7 @@
 
             <div class="${properties.kcFormGroupClass!}">
                 <div class="${properties.kcLabelWrapperClass!}">
-                    <label for="emailCode" class="${properties.kcLabelClass!}">${msg("emailOtpForm", otpLength)}</label>
+                    <label for="emailCode" class="${properties.kcLabelClass!}">${msg("emailOtpForm", otpLength)}<#if maskedEmail??>: <strong>${kcSanitize(maskedEmail)?no_esc}</strong></#if></label>
                 </div>
 
             <div class="${properties.kcInputWrapperClass!}">

--- a/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormTest.java
+++ b/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormTest.java
@@ -228,6 +228,83 @@ class EmailAuthenticatorFormTest {
         }
     }
 
+
+    @Nested
+    @DisplayName("Masked email exposure tests")
+    class MaskedEmailExposureTests {
+
+        private BfpTestableForm form;
+        private AuthenticationFlowContext context;
+        private UserModel user;
+        private AuthenticationSessionModel session;
+        private LoginFormsProvider loginForm;
+        private AuthenticationExecutionModel execution;
+        private AuthenticatorConfigModel config;
+
+        @BeforeEach
+        void setUp() {
+            form = new BfpTestableForm();
+            context = mock(AuthenticationFlowContext.class);
+            user = mock(UserModel.class);
+            session = mock(AuthenticationSessionModel.class);
+            loginForm = mock(LoginFormsProvider.class);
+            execution = mock(AuthenticationExecutionModel.class);
+            config = mock(AuthenticatorConfigModel.class);
+
+            when(context.getUser()).thenReturn(user);
+            when(context.getAuthenticationSession()).thenReturn(session);
+            when(context.form()).thenReturn(loginForm);
+            when(context.getExecution()).thenReturn(execution);
+            when(execution.getId()).thenReturn("test-exec");
+            when(loginForm.setExecution(anyString())).thenReturn(loginForm);
+            when(loginForm.setAttribute(anyString(), any())).thenReturn(loginForm);
+            when(loginForm.createForm(anyString())).thenReturn(mock(Response.class));
+            when(context.getAuthenticatorConfig()).thenReturn(config);
+            when(session.getAuthNote(EmailConstants.CODE)).thenReturn(OtpHashUtils.hash("123456"));
+            when(session.getAuthNote(EmailConstants.CODE_TTL)).thenReturn(String.valueOf(System.currentTimeMillis() + 300_000));
+            when(session.getAuthNote(EmailConstants.CODE_RESEND_AVAILABLE_AFTER)).thenReturn(null);
+        }
+
+        @Test
+        @DisplayName("Should expose masked email when enabled")
+        void shouldExposeMaskedEmailWhenEnabled() {
+            when(user.getEmail()).thenReturn("username@example.com");
+            when(config.getConfig()).thenReturn(Map.of(
+                    EmailConstants.SHOW_MASKED_EMAIL_ON_OTP_FORM, "true",
+                    EmailConstants.CODE_LENGTH, "6"));
+
+            form.authenticate(context);
+
+            verify(loginForm).setAttribute("maskedEmail", "u***e@example.com");
+        }
+
+        @Test
+        @DisplayName("Should not expose masked email when disabled")
+        void shouldNotExposeMaskedEmailWhenDisabled() {
+            when(user.getEmail()).thenReturn("username@example.com");
+            when(config.getConfig()).thenReturn(Map.of(
+                    EmailConstants.SHOW_MASKED_EMAIL_ON_OTP_FORM, "false",
+                    EmailConstants.CODE_LENGTH, "6"));
+
+            form.authenticate(context);
+
+            verify(loginForm, never()).setAttribute(eq("maskedEmail"), any());
+        }
+
+        @Test
+        @DisplayName("Should expose masked email for short local parts")
+        void shouldExposeMaskedEmailForShortLocalParts() {
+            when(user.getEmail()).thenReturn("ab@example.com");
+            when(config.getConfig()).thenReturn(Map.of(
+                    EmailConstants.SHOW_MASKED_EMAIL_ON_OTP_FORM, "true",
+                    EmailConstants.CODE_LENGTH, "6"));
+
+            form.authenticate(context);
+
+            verify(loginForm).setAttribute("maskedEmail", "a***@example.com");
+        }
+    }
+
     @Test
     @DisplayName("Should return correct brute force error message")
     void testDisabledByBruteForceError() {

--- a/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailConstantsTest.java
+++ b/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailConstantsTest.java
@@ -48,6 +48,13 @@ class EmailConstantsTest {
     }
 
     @Test
+    @DisplayName("Should have masked email disabled by default")
+    void testDefaultShowMaskedEmailOnOtpForm() {
+        assertFalse(EmailConstants.DEFAULT_SHOW_MASKED_EMAIL_ON_OTP_FORM,
+                "Masked email display should be disabled by default");
+    }
+
+    @Test
     @DisplayName("Should not be instantiable")
     void testUtilityClassPattern() {
         try {
@@ -76,5 +83,6 @@ class EmailConstantsTest {
         assertEquals("simulationMode", EmailConstants.SIMULATION_MODE);
         assertEquals("resendCooldown", EmailConstants.RESEND_COOLDOWN);
         assertEquals("emailCodeResendAvailableAfter", EmailConstants.CODE_RESEND_AVAILABLE_AFTER);
+        assertEquals("showMaskedEmailOnOtpForm", EmailConstants.SHOW_MASKED_EMAIL_ON_OTP_FORM);
     }
 }

--- a/website/docs/configuration/authentication-flow.mdx
+++ b/website/docs/configuration/authentication-flow.mdx
@@ -155,6 +155,7 @@ Click the **⚙️ Settings** icon on the **"Email OTP"** row to open the authen
 | **Simulation mode** | Log codes to server logs instead of sending emails | `false` | `false` |
 | **Resend cooldown** | Seconds a user must wait before requesting a new code | `30` | `60` |
 | **Max code attempts** | Wrong attempts allowed before the code is invalidated | `5` | `3` |
+| **Show masked email on OTP form** | Show a masked version of the destination email on the OTP screen | `false` | `true` |
 | **Skip setup** | Skip enrollment for users who already have an email address | `true` | `true` |
 
 ### Setting details
@@ -182,6 +183,11 @@ Prevents users from spamming the "Resend code" button. The default of `30` secon
 
 #### Max code attempts
 After this many wrong attempts, the current code is invalidated and the user must request a new one. Lower values (e.g. `3`) make brute-forcing harder but may frustrate users who mistype frequently.
+
+#### Show masked email on OTP form
+When enabled, the authenticator injects a server-generated `maskedEmail` attribute into the OTP login form and displays it to the user, for example `u***e@example.com`. This improves UX by confirming where the code was sent without exposing the full address.
+
+This setting is intentionally implemented server-side. It does **not** depend on `${user.email!}` being present in the FreeMarker login template context.
 
 #### Skip setup
 When `true`, users who already have an email address on their Keycloak account skip the enrollment required action and go straight to the OTP prompt. This is the recommended setting when an admin has enforced 2FA for existing users — they are not forced through a setup wizard on their next login.

--- a/website/docs/configuration/template-customization.mdx
+++ b/website/docs/configuration/template-customization.mdx
@@ -72,3 +72,10 @@ After editing templates or properties files, rebuild and redeploy: `mvn clean pa
 ## Supported Languages & Adding Translations
 
 The authenticator ships with 11 built-in languages. For the full list, how to add a new language, and a complete translation keys reference, see the [Localization guide](../localization).
+
+
+## OTP Login Form Note
+
+If you want to show the destination email address on the OTP login screen, prefer the built-in authenticator setting **Show masked email on OTP form** instead of relying on `${user.email!}` in the FreeMarker login template.
+
+When that setting is enabled, the authenticator passes a server-generated `maskedEmail` value to the form template. This is more reliable across Keycloak versions because the login template context does not always expose a populated `user` object during the OTP step.

--- a/website/docs/local-testing.mdx
+++ b/website/docs/local-testing.mdx
@@ -183,12 +183,14 @@ Create an [App Password](https://myaccount.google.com/apppasswords) — requires
 
 Click **⚙️** on the **"Email OTP"** row:
 
-| Setting         | Value   |
-| --------------- | ------- |
-| Code length     | `6`     |
-| Time-to-live    | `300`   |
-| Simulation mode | `false` |
-| Resend cooldown | `30`    |
+| Setting                        | Value   |
+| ------------------------------ | ------- |
+| Code length                    | `6`     |
+| Time-to-live                   | `300`   |
+| Simulation mode                | `false` |
+| Resend cooldown                | `30`    |
+| Max code attempts              | `5`     |
+| Show Masked Email on OTP Form  | `true`  |
 
 ---
 
@@ -226,7 +228,15 @@ podman logs -f keycloak-test | grep "SIMULATION MODE"
 # ***** SIMULATION MODE ***** Email code send to test@example.com for user testuser is: 123456
 ```
 
-### Test 6 — Language Support
+### Test 6 — Masked Email Display
+
+1. In **Authentication → Flows**, open **⚙️** settings for **Email OTP**
+2. Enable **Show Masked Email on OTP Form**
+3. Login as `testuser`
+4. Expected: the OTP screen shows a masked destination such as `t***r@example.com`
+5. Confirm the full email address is not displayed
+
+### Test 7 — Language Support
 
 Verify that all 11 built-in translations display correctly.
 


### PR DESCRIPTION
## Summary
- add an optional authenticator setting to show a masked email on the OTP form
- inject `maskedEmail` server-side instead of relying on `${user.email!}` in the login template
- add regression tests and update local + website documentation

## Why
Discussion #104 reported that on Keycloak 26.6 with plugin v26.4.0 the OTP template only exposed `attemptedUsername`, so `${user.email!}` was empty. This PR fixes that by passing a server-generated masked email to the form template when enabled.

## Changes
- new config key: `showMaskedEmailOnOtpForm` (default `false`)
- new OTP form attribute: `maskedEmail`
- UI renders masked email like `u***e@example.com`
- docs updated in README, local testing docs, and website docs

## Verification
```bash
mvn -q -Dtest=EmailAuthenticatorFormTest,EmailConstantsTest test
```
