### PR TITLE
fix: decouple isConfiguredFor from realm flow scanning (#129, #108, #112, #50)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <artifactId>keycloak-2fa-email-authenticator</artifactId>
     <groupId>io.github.mesutpiskin</groupId>
-    <version>26.4.0</version>
+    <version>26.4.2</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
 

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorCredentialProvider.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorCredentialProvider.java
@@ -1,7 +1,5 @@
 package com.mesutpiskin.keycloak.auth.email;
 
-import java.util.List;
-
 import org.jboss.logging.Logger;
 import org.keycloak.credential.CredentialInput;
 import org.keycloak.credential.CredentialInputValidator;
@@ -9,7 +7,6 @@ import org.keycloak.credential.CredentialModel;
 import org.keycloak.credential.CredentialProvider;
 import org.keycloak.credential.CredentialTypeMetadata;
 import org.keycloak.credential.CredentialTypeMetadataContext;
-import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
@@ -39,40 +36,10 @@ public class EmailAuthenticatorCredentialProvider
         if (!supportsCredentialType(credentialType)) {
             return false;
         }
-        if (user.credentialManager()
+        return user.credentialManager()
                 .getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID)
                 .findAny()
-                .isPresent()) {
-            return true;
-        }
-        // When skip-setup is enabled, users with an email are considered configured without
-        // explicit enrollment. This enables "Try Another Way" selection and admin-enforced 2FA.
-        return isSkipSetupEnabled(realm) && user.getEmail() != null && !user.getEmail().isBlank();
-    }
-
-    private boolean isSkipSetupEnabled(RealmModel realm) {
-        List<Boolean> values = realm.getAuthenticationFlowsStream()
-                .flatMap(flow -> realm.getAuthenticationExecutionsStream(flow.getId()))
-                .filter(exec -> EmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator())
-                        || ConditionalEmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator()))
-                .map(exec -> {
-                    String configId = exec.getAuthenticatorConfig();
-                    if (configId != null) {
-                        AuthenticatorConfigModel config = realm.getAuthenticatorConfigById(configId);
-                        if (config != null && config.getConfig() != null) {
-                            return Boolean.parseBoolean(
-                                    config.getConfig().getOrDefault(EmailConstants.SKIP_SETUP,
-                                            String.valueOf(EmailConstants.DEFAULT_SKIP_SETUP)));
-                        }
-                    }
-                    return EmailConstants.DEFAULT_SKIP_SETUP;
-                })
-                .toList();
-        // If no email authenticator executions exist in any flow, fall back to the default.
-        // Otherwise return true if *any* execution has skip-setup enabled so that the behaviour
-        // is deterministic even when the same authenticator is configured in multiple flows.
-        return values.isEmpty() ? EmailConstants.DEFAULT_SKIP_SETUP
-                : values.stream().anyMatch(Boolean::booleanValue);
+                .isPresent();
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -428,10 +428,20 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
         return true;
     }
 
+    /**
+     * Eligibility for this authenticator is based on the user having a usable email
+     * address — no explicit enrollment step is required. A user with an email can
+     * always receive an email OTP. This keeps the authenticator decoupled from the
+     * realm-level credential store and makes the plugin appear as a valid option in
+     * "Try Another Way" alternative lists.
+     */
     @Override
     public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
-        EmailAuthenticatorCredentialProvider provider = getCredentialProvider(session);
-        return provider != null && provider.isConfiguredFor(realm, user, getType(session));
+        if (user == null) {
+            return false;
+        }
+        String email = user.getEmail();
+        return email != null && !email.isBlank();
     }
 
     @Override
@@ -440,9 +450,16 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
                 EmailAuthenticatorCredentialProviderFactory.PROVIDER_ID);
     }
 
+    /**
+     * No automatic required action is registered. Users with an email are already
+     * considered configured (see {@link #configuredFor}); users without an email
+     * cannot enrol via this authenticator and the flow surfaces the missing-email
+     * error at {@link #authenticate} time. Account-UI enrolment remains available
+     * via {@link EmailAuthenticatorRequiredAction}.
+     */
     @Override
     public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
-        user.addRequiredAction(EmailAuthenticatorRequiredAction.PROVIDER_ID);
+        // intentional no-op
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
@@ -127,10 +127,7 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
                         ProviderConfigProperty.STRING_TYPE, String.valueOf(EmailConstants.DEFAULT_MAX_ATTEMPTS)),
                 new ProviderConfigProperty(EmailConstants.SHOW_MASKED_EMAIL_ON_OTP_FORM, "Show Masked Email on OTP Form",
                         "If enabled, displays a masked version of the user's email address on the OTP entry form after the code is sent.",
-                        ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_SHOW_MASKED_EMAIL_ON_OTP_FORM)),
-                new ProviderConfigProperty(EmailConstants.SKIP_SETUP, "Skip Setup",
-                        "When enabled, users with an email address are considered configured without needing to complete the enrollment flow. Useful for admin-enforced 2FA.",
-                        ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_SKIP_SETUP)));
+                        ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_SHOW_MASKED_EMAIL_ON_OTP_FORM)));
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorRequiredAction.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorRequiredAction.java
@@ -47,9 +47,9 @@ public class EmailAuthenticatorRequiredAction implements RequiredActionProvider,
 
     @Override
     public void evaluateTriggers(RequiredActionContext context) {
-        // isConfiguredFor() in EmailAuthenticatorCredentialProvider handles the skipSetup case
-        // (returns true when user has email and skipSetup is enabled), so auto-enrollment
-        // here is not needed and would create unwanted credentials in account management.
+        // No automatic trigger. Enrolment is voluntary via the account console — the
+        // login flow never requires it because EmailAuthenticatorForm.configuredFor
+        // treats any user with an email as eligible.
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
@@ -202,16 +202,19 @@ public final class EmailConstants {
 	public static final boolean DEFAULT_SHOW_MASKED_EMAIL_ON_OTP_FORM = false;
 
 	/**
-	 * Configuration key for skipping the setup required action.
-	 * When enabled, users with an email address are considered configured
-	 * without needing to complete the enrollment flow. Useful for
-	 * admin-enforced 2FA where all users already have email addresses.
+	 * @deprecated The {@code skipSetup} configuration flag is no longer read by the
+	 * authenticator. Email-OTP eligibility is now derived solely from whether the
+	 * user has an email address, so explicit enrolment is never required for the
+	 * login flow. The constant is kept so existing realm configurations containing
+	 * the key continue to deserialize without error.
 	 */
+	@Deprecated
 	public static final String SKIP_SETUP = "skipSetup";
 
 	/**
-	 * Default skip-setup setting (enabled, so users with an email skip enrollment).
+	 * @deprecated See {@link #SKIP_SETUP}.
 	 */
+	@Deprecated
 	public static final boolean DEFAULT_SKIP_SETUP = true;
 
 	/**

--- a/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorCredentialProviderTest.java
+++ b/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorCredentialProviderTest.java
@@ -2,45 +2,44 @@ package com.mesutpiskin.keycloak.auth.email;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.keycloak.models.AuthenticationExecutionModel;
-import org.keycloak.models.AuthenticationFlowModel;
-import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.SubjectCredentialManager;
 import org.keycloak.models.UserModel;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+/**
+ * Verifies that {@link EmailAuthenticatorCredentialProvider#isConfiguredFor}
+ * depends solely on stored credentials and does not touch realm flow state.
+ * The previous flow-scanning behaviour (issue #129) is intentionally absent.
+ */
 class EmailAuthenticatorCredentialProviderTest {
 
     private EmailAuthenticatorCredentialProvider provider;
-    private KeycloakSession session;
     private RealmModel realm;
     private UserModel user;
     private SubjectCredentialManager credentialManager;
 
     @BeforeEach
     void setUp() {
-        session = mock(KeycloakSession.class);
+        KeycloakSession session = mock(KeycloakSession.class);
         realm = mock(RealmModel.class);
         user = mock(UserModel.class);
         credentialManager = mock(SubjectCredentialManager.class);
         when(user.credentialManager()).thenReturn(credentialManager);
-        when(realm.getAuthenticationFlowsStream()).thenReturn(Stream.empty());
         provider = new EmailAuthenticatorCredentialProvider(session);
     }
 
     @Test
+    @DisplayName("Returns true only when a stored credential exists")
     void testIsConfiguredFor_WithStoredCredential() {
         var credential = new EmailAuthenticatorCredentialModel();
         when(credentialManager.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
@@ -52,174 +51,32 @@ class EmailAuthenticatorCredentialProviderTest {
     }
 
     @Test
-    void testIsConfiguredFor_WithNoStoredCredential_NoSkipSetup() {
+    @DisplayName("Returns false when no stored credential exists, regardless of user email")
+    void testIsConfiguredFor_NoStoredCredential() {
         when(credentialManager.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
                 .thenReturn(Stream.empty());
 
         boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
 
-        assertFalse(result, "Should not be configured when no stored credential and no skip-setup config");
+        assertFalse(result, "Provider should report false when no credential is stored");
     }
 
     @Test
+    @DisplayName("Returns false for unsupported credential types")
     void testIsConfiguredFor_WrongCredentialType() {
         boolean result = provider.isConfiguredFor(realm, user, "wrong-type");
 
         assertFalse(result, "Should return false for unsupported credential type");
     }
 
-    @Nested
-    @DisplayName("Skip-setup fallback for users with email")
-    class SkipSetupTests {
+    @Test
+    @DisplayName("Does not scan realm flows (decoupled from flow execution config)")
+    void testIsConfiguredFor_DoesNotTouchRealmFlows() {
+        when(credentialManager.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
+                .thenReturn(Stream.empty());
 
-        private AuthenticationFlowModel flow;
-        private AuthenticationExecutionModel execution;
-        private AuthenticatorConfigModel config;
+        provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
 
-        @BeforeEach
-        void setUp() {
-            when(credentialManager.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
-                    .thenReturn(Stream.empty());
-
-            flow = mock(AuthenticationFlowModel.class);
-            execution = mock(AuthenticationExecutionModel.class);
-            config = mock(AuthenticatorConfigModel.class);
-
-            when(flow.getId()).thenReturn("flow-1");
-            when(realm.getAuthenticationFlowsStream()).thenReturn(Stream.of(flow));
-            when(realm.getAuthenticationExecutionsStream("flow-1")).thenReturn(Stream.of(execution));
-            when(execution.getAuthenticator()).thenReturn(EmailAuthenticatorFormFactory.PROVIDER_ID);
-            when(execution.getAuthenticatorConfig()).thenReturn("config-1");
-            when(realm.getAuthenticatorConfigById("config-1")).thenReturn(config);
-        }
-
-        @Test
-        @DisplayName("Returns true when skipSetup=true and user has email")
-        void testSkipSetup_true_withEmail() {
-            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "true"));
-            when(user.getEmail()).thenReturn("user@example.com");
-
-            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
-
-            assertTrue(result, "Should be configured when skipSetup=true and user has email");
-        }
-
-        @Test
-        @DisplayName("Returns false when skipSetup=false and no stored credential")
-        void testSkipSetup_false_noCredential() {
-            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "false"));
-            when(user.getEmail()).thenReturn("user@example.com");
-
-            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
-
-            assertFalse(result, "Should not be configured when skipSetup=false and no stored credential");
-        }
-
-        @Test
-        @DisplayName("Returns false when skipSetup=true but user has no email")
-        void testSkipSetup_true_noEmail() {
-            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "true"));
-            when(user.getEmail()).thenReturn(null);
-
-            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
-
-            assertFalse(result, "Should not be configured when user has no email even with skipSetup=true");
-        }
-
-        @Test
-        @DisplayName("Returns false when skipSetup=true but user has blank email")
-        void testSkipSetup_true_blankEmail() {
-            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "true"));
-            when(user.getEmail()).thenReturn("   ");
-
-            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
-
-            assertFalse(result, "Should not be configured when user has blank email even with skipSetup=true");
-        }
-
-        @Test
-        @DisplayName("Returns true when conditional authenticator has skipSetup=true and user has email")
-        void testConditionalAuthenticator_skipSetup_true_withEmail() {
-            when(execution.getAuthenticator()).thenReturn(ConditionalEmailAuthenticatorFormFactory.PROVIDER_ID);
-            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "true"));
-            when(user.getEmail()).thenReturn("user@example.com");
-
-            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
-
-            assertTrue(result, "Should be configured for conditional authenticator with skipSetup=true and email");
-        }
-
-        @Test
-        @DisplayName("Returns true with default skipSetup (true) when no config is set")
-        void testDefaultSkipSetup_withEmail() {
-            when(execution.getAuthenticatorConfig()).thenReturn(null);
-            when(user.getEmail()).thenReturn("user@example.com");
-
-            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
-
-            assertTrue(result, "Should be configured by default (skipSetup defaults to true) when user has email");
-        }
-
-        @Test
-        @DisplayName("Stored credential takes precedence over skipSetup=false")
-        void testStoredCredential_overridesSkipSetupFalse() {
-            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "false"));
-            when(user.getEmail()).thenReturn("user@example.com");
-
-            var credential = new EmailAuthenticatorCredentialModel();
-            when(credentialManager.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
-                    .thenReturn(Stream.of(credential));
-
-            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
-
-            assertTrue(result, "Should be configured when stored credential exists, regardless of skipSetup");
-        }
-
-        @Test
-        @DisplayName("Returns true when at least one of multiple flows has skipSetup=true (anyMatch)")
-        void testMultipleFlows_anySkipSetupTrue_returnsTrue() {
-            AuthenticationFlowModel flow2 = mock(AuthenticationFlowModel.class);
-            AuthenticationExecutionModel exec2 = mock(AuthenticationExecutionModel.class);
-            AuthenticatorConfigModel config2 = mock(AuthenticatorConfigModel.class);
-
-            when(flow2.getId()).thenReturn("flow-2");
-            when(realm.getAuthenticationFlowsStream()).thenReturn(Stream.of(flow, flow2));
-            when(realm.getAuthenticationExecutionsStream("flow-2")).thenReturn(Stream.of(exec2));
-            when(exec2.getAuthenticator()).thenReturn(EmailAuthenticatorFormFactory.PROVIDER_ID);
-            when(exec2.getAuthenticatorConfig()).thenReturn("config-2");
-            when(realm.getAuthenticatorConfigById("config-2")).thenReturn(config2);
-
-            // First flow: skipSetup=false, second flow: skipSetup=true
-            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "false"));
-            when(config2.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "true"));
-            when(user.getEmail()).thenReturn("user@example.com");
-
-            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
-
-            assertTrue(result, "Should be configured when any flow has skipSetup=true");
-        }
-
-        @Test
-        @DisplayName("Returns false when all flows have skipSetup=false and no stored credential")
-        void testMultipleFlows_allSkipSetupFalse_returnsFalse() {
-            AuthenticationFlowModel flow2 = mock(AuthenticationFlowModel.class);
-            AuthenticationExecutionModel exec2 = mock(AuthenticationExecutionModel.class);
-            AuthenticatorConfigModel config2 = mock(AuthenticatorConfigModel.class);
-
-            when(flow2.getId()).thenReturn("flow-2");
-            when(realm.getAuthenticationFlowsStream()).thenReturn(Stream.of(flow, flow2));
-            when(realm.getAuthenticationExecutionsStream("flow-2")).thenReturn(Stream.of(exec2));
-            when(exec2.getAuthenticator()).thenReturn(EmailAuthenticatorFormFactory.PROVIDER_ID);
-            when(exec2.getAuthenticatorConfig()).thenReturn("config-2");
-            when(realm.getAuthenticatorConfigById("config-2")).thenReturn(config2);
-
-            when(config.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "false"));
-            when(config2.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "false"));
-            when(user.getEmail()).thenReturn("user@example.com");
-
-            boolean result = provider.isConfiguredFor(realm, user, EmailAuthenticatorCredentialModel.TYPE_ID);
-
-            assertFalse(result, "Should not be configured when all flows have skipSetup=false and no stored credential");
-        }
+        verifyNoInteractions(realm);
     }
 }

--- a/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormTest.java
+++ b/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormTest.java
@@ -72,34 +72,52 @@ class EmailAuthenticatorFormTest {
     }
 
     @Test
-    @DisplayName("Should be configured for user with valid credential")
-    void testConfiguredFor_withValidSetup() {
+    @DisplayName("configuredFor returns true when the user has a non-blank email")
+    void testConfiguredFor_userWithEmail() {
         KeycloakSession session = mock(KeycloakSession.class);
         RealmModel realm = mock(RealmModel.class);
         UserModel user = mock(UserModel.class);
+        when(user.getEmail()).thenReturn("alice@example.com");
 
-        // This test verifies the method can be called without exceptions
-        assertDoesNotThrow(() -> {
-            try {
-                authenticator.configuredFor(session, realm, user);
-            } catch (NullPointerException e) {
-                // Expected when credential provider is not available
-                // This is acceptable for unit test
-            }
-        });
+        assertTrue(authenticator.configuredFor(session, realm, user),
+                "Users with an email address must be eligible to receive an OTP without enrolment");
     }
 
     @Test
-    @DisplayName("Should set required action on user")
-    void testSetRequiredActions() {
+    @DisplayName("configuredFor returns false when the user has no email")
+    void testConfiguredFor_userWithoutEmail() {
+        KeycloakSession session = mock(KeycloakSession.class);
+        RealmModel realm = mock(RealmModel.class);
+        UserModel user = mock(UserModel.class);
+        when(user.getEmail()).thenReturn(null);
+
+        assertFalse(authenticator.configuredFor(session, realm, user),
+                "Users without an email cannot use the email authenticator");
+    }
+
+    @Test
+    @DisplayName("configuredFor returns false for blank emails")
+    void testConfiguredFor_blankEmail() {
+        KeycloakSession session = mock(KeycloakSession.class);
+        RealmModel realm = mock(RealmModel.class);
+        UserModel user = mock(UserModel.class);
+        when(user.getEmail()).thenReturn("   ");
+
+        assertFalse(authenticator.configuredFor(session, realm, user),
+                "Blank emails should be treated as no email");
+    }
+
+    @Test
+    @DisplayName("setRequiredActions is a no-op; the login flow never triggers enrolment")
+    void testSetRequiredActions_isNoOp() {
         KeycloakSession session = mock(KeycloakSession.class);
         RealmModel realm = mock(RealmModel.class);
         UserModel user = mock(UserModel.class);
 
         authenticator.setRequiredActions(session, realm, user);
 
-        // Verify that addRequiredAction was called with the correct provider ID
-        verify(user).addRequiredAction(EmailAuthenticatorRequiredAction.PROVIDER_ID);
+        verify(user, never()).addRequiredAction(EmailAuthenticatorRequiredAction.PROVIDER_ID);
+        verify(user, never()).addRequiredAction(anyString());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Cleans up the eligibility model for the email authenticator so the credential
provider and the form authenticator answer distinct, simpler questions.

Closes #129, #108, #112, #50.

### What changed

- **`EmailAuthenticatorCredentialProvider.isConfiguredFor`** now returns
  `true` only when the user has a stored `email-authenticator` credential.
  It no longer scans every authentication flow in the realm to read
  per-execution config — the core concern raised in #129. As a side
  effect, the account console reports the credential as configured only
  when one actually exists, removing the "always active" entry from #108.

- **`EmailAuthenticatorForm.configuredFor`** is now derived purely from
  `user.getEmail()`. Any user with an email is eligible to receive an OTP
  without a prior enrolment step. This restores the pre-#107 experience
  for admin-provisioned users (#112) and makes the plugin appear in
  Keycloak's "Try Another Way" alternatives whenever an email is
  available (#50).

- **`EmailAuthenticatorForm.setRequiredActions`** is now a no-op. The
  `email-authenticator-setup` required action remains available for
  voluntary enrolment via the account console, but the login flow never
  forces it.

- The `skipSetup` authenticator-config property is removed from the
  admin UI (it no longer has a behavioural effect). The constants in
  `EmailConstants` are kept as `@Deprecated` so existing realm
  configurations that still contain the key deserialize cleanly.

### Why this matters for each issue

| Issue | Resolution |
| --- | --- |
| #129 | Provider no longer reads per-execution config or walks `getAuthenticationFlowsStream`. Each layer has a single, clear responsibility. |
| #108 | `userCredentialMetadatas` is empty when no credential is stored, because `isConfiguredFor` no longer returns true based on email presence. |
| #112 | Admin-provisioned users with an email keep working without a setup screen, because `EmailAuthenticatorForm.configuredFor` returns true. |
| #50 | The plugin now reports itself as configured for any user with an email, so Keycloak lists it among "Try Another Way" alternatives. |

### Backward compatibility

- Realms that already saved `skipSetup=true` or `skipSetup=false` continue
  to load — the key is silently ignored.
- Users who previously had the `email-authenticator-setup` required
  action added by `setRequiredActions` will not have it re-added, but the
  existing required action is removed cleanly the next time the user
  reaches the setup form (existing behaviour in
  `EmailAuthenticatorRequiredAction.processAction`).

## Test plan

- [x] `mvn test` — all 66 unit tests pass
- [x] `EmailAuthenticatorCredentialProviderTest` rewritten to cover the
      new contract (stored credential only, no realm interaction)
- [x] `EmailAuthenticatorFormTest` extended to verify `configuredFor`
      truth-table on email presence and that `setRequiredActions` is a
      no-op
- [ ] Manual smoke test in a real Keycloak instance: admin-enforced 2FA
      with an admin-provisioned user reaches the OTP form directly
- [ ] Manual smoke test: a user with both TOTP and Email OTP configured
      as alternatives can pick Email OTP from "Try Another Way"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
