### PR TITLE
fix: gate configuredFor on enrolment and restore skipSetup opt-in (#108 follow-up)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <artifactId>keycloak-2fa-email-authenticator</artifactId>
     <groupId>io.github.mesutpiskin</groupId>
-    <version>26.4.2</version>
+    <version>26.4.3</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
 

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorForm.java
@@ -429,19 +429,84 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
     }
 
     /**
-     * Eligibility for this authenticator is based on the user having a usable email
-     * address — no explicit enrollment step is required. A user with an email can
-     * always receive an email OTP. This keeps the authenticator decoupled from the
-     * realm-level credential store and makes the plugin appear as a valid option in
-     * "Try Another Way" alternative lists.
+     * Eligibility rules for the email authenticator:
+     * <ol>
+     * <li>A user with a stored email-authenticator credential is always
+     * configured.</li>
+     * <li>A user without an email address is never configured — the
+     * authenticator has nowhere to send the OTP.</li>
+     * <li>Otherwise, the user is reported as configured only when an admin has
+     * explicitly opted in to the "any user with email is eligible" behaviour by
+     * setting {@link EmailConstants#SKIP_SETUP skipSetup} = {@code true} on at
+     * least one email-authenticator execution in the realm.</li>
+     * </ol>
+     * The default ({@code skipSetup=false}) is intentional: it matches the
+     * Keycloak convention that {@code configuredFor=true} means "the user has
+     * enrolled this credential", so "Conditional - User Configured" sub-flows
+     * are not triggered for users who have neither enrolled nor been explicitly
+     * targeted by the admin's flow design.
      */
     @Override
     public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
         if (user == null) {
             return false;
         }
+
         String email = user.getEmail();
-        return email != null && !email.isBlank();
+        if (email == null || email.isBlank()) {
+            return false;
+        }
+
+        if (hasStoredEmailCredential(user)) {
+            return true;
+        }
+
+        return isSkipSetupEnabledForRealm(realm);
+    }
+
+    private boolean hasStoredEmailCredential(UserModel user) {
+        var credentialManager = user.credentialManager();
+        if (credentialManager == null) {
+            return false;
+        }
+        return credentialManager
+                .getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID)
+                .findAny()
+                .isPresent();
+    }
+
+    /**
+     * Looks up the {@code skipSetup} flag on any email-authenticator (regular or
+     * conditional) execution in the realm. A single explicit {@code true} opts
+     * the realm into the permissive eligibility model; otherwise the strict
+     * default applies. This scan is intentionally kept in the form authenticator
+     * (not the credential provider) so the provider keeps the clean contract
+     * introduced for issue #129 (stored credentials only).
+     */
+    private boolean isSkipSetupEnabledForRealm(RealmModel realm) {
+        if (realm == null) {
+            return EmailConstants.DEFAULT_SKIP_SETUP;
+        }
+        return realm.getAuthenticationFlowsStream()
+                .flatMap(flow -> realm.getAuthenticationExecutionsStream(flow.getId()))
+                .filter(exec -> EmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator())
+                        || ConditionalEmailAuthenticatorFormFactory.PROVIDER_ID.equals(exec.getAuthenticator()))
+                .map(exec -> {
+                    String configId = exec.getAuthenticatorConfig();
+                    if (configId == null) {
+                        return null;
+                    }
+                    AuthenticatorConfigModel cfg = realm.getAuthenticatorConfigById(configId);
+                    if (cfg == null || cfg.getConfig() == null) {
+                        return null;
+                    }
+                    return cfg.getConfig().get(EmailConstants.SKIP_SETUP);
+                })
+                .filter(value -> value != null && !value.isBlank())
+                .map(value -> Boolean.parseBoolean(value.trim()))
+                .filter(Boolean::booleanValue)
+                .findAny()
+                .orElse(EmailConstants.DEFAULT_SKIP_SETUP);
     }
 
     @Override
@@ -451,11 +516,13 @@ public class EmailAuthenticatorForm extends AbstractUsernameFormAuthenticator
     }
 
     /**
-     * No automatic required action is registered. Users with an email are already
-     * considered configured (see {@link #configuredFor}); users without an email
-     * cannot enrol via this authenticator and the flow surfaces the missing-email
-     * error at {@link #authenticate} time. Account-UI enrolment remains available
-     * via {@link EmailAuthenticatorRequiredAction}.
+     * No automatic required action is registered. Voluntary enrolment remains
+     * available via {@link EmailAuthenticatorRequiredAction} (account console).
+     * Admins who want to force enrolment for non-configured users can either
+     * add the 'email-authenticator-setup' required action manually, or set
+     * {@link EmailConstants#SKIP_SETUP skipSetup}={@code true} on the
+     * authenticator execution so users with an email are considered configured
+     * without enrolment.
      */
     @Override
     public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
@@ -127,7 +127,10 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
                         ProviderConfigProperty.STRING_TYPE, String.valueOf(EmailConstants.DEFAULT_MAX_ATTEMPTS)),
                 new ProviderConfigProperty(EmailConstants.SHOW_MASKED_EMAIL_ON_OTP_FORM, "Show Masked Email on OTP Form",
                         "If enabled, displays a masked version of the user's email address on the OTP entry form after the code is sent.",
-                        ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_SHOW_MASKED_EMAIL_ON_OTP_FORM)));
+                        ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_SHOW_MASKED_EMAIL_ON_OTP_FORM)),
+                new ProviderConfigProperty(EmailConstants.SKIP_SETUP, "Treat any user with an email as configured",
+                        "When enabled, users with an email address are reported as configured for the email authenticator even if they have never enrolled — useful for admin-provisioned 2FA and for showing the plugin in 'Try Another Way' alternatives. Leave disabled (default) when you rely on 'Conditional - User Configured' sub-flows: the conditional only triggers for users who have actually enrolled.",
+                        ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_SKIP_SETUP)));
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorRequiredAction.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorRequiredAction.java
@@ -47,9 +47,11 @@ public class EmailAuthenticatorRequiredAction implements RequiredActionProvider,
 
     @Override
     public void evaluateTriggers(RequiredActionContext context) {
-        // No automatic trigger. Enrolment is voluntary via the account console — the
-        // login flow never requires it because EmailAuthenticatorForm.configuredFor
-        // treats any user with an email as eligible.
+        // No automatic trigger. Enrolment is voluntary via the account console;
+        // admins who want to force enrolment can add the
+        // 'email-authenticator-setup' required action manually, or set
+        // skipSetup=true on the email-authenticator execution to bypass
+        // enrolment entirely for users with an email address.
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
@@ -202,20 +202,32 @@ public final class EmailConstants {
 	public static final boolean DEFAULT_SHOW_MASKED_EMAIL_ON_OTP_FORM = false;
 
 	/**
-	 * @deprecated The {@code skipSetup} configuration flag is no longer read by the
-	 * authenticator. Email-OTP eligibility is now derived solely from whether the
-	 * user has an email address, so explicit enrolment is never required for the
-	 * login flow. The constant is kept so existing realm configurations containing
-	 * the key continue to deserialize without error.
+	 * Configuration key controlling whether users with an email address but no
+	 * stored email-authenticator credential are reported as configured by
+	 * {@link com.mesutpiskin.keycloak.auth.email.EmailAuthenticatorForm#configuredFor}.
+	 * <p>
+	 * When {@code true}, any user with an email is eligible to receive an OTP
+	 * without prior enrolment — useful for admin-provisioned accounts (#112) and
+	 * for showing the plugin in Keycloak's "Try Another Way" alternative list
+	 * (#50).
+	 * </p>
+	 * <p>
+	 * When {@code false} (the default), only users with a stored credential are
+	 * reported as configured, matching Keycloak's convention for built-in
+	 * authenticators. This is the setting "Conditional - User Configured"
+	 * sub-flows expect, so non-enrolled users are not unexpectedly prompted for
+	 * an email OTP (#108 follow-up).
+	 * </p>
 	 */
-	@Deprecated
 	public static final String SKIP_SETUP = "skipSetup";
 
 	/**
-	 * @deprecated See {@link #SKIP_SETUP}.
+	 * Default value for {@link #SKIP_SETUP}. {@code false} is the strict,
+	 * convention-aligned default so conditional sub-flows behave as admins
+	 * expect; opt in to the permissive behaviour by setting the flag to
+	 * {@code true} on the email-authenticator execution.
 	 */
-	@Deprecated
-	public static final boolean DEFAULT_SKIP_SETUP = true;
+	public static final boolean DEFAULT_SKIP_SETUP = false;
 
 	/**
 	 * Millisecond rounding offset used for converting milliseconds to seconds.

--- a/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormTest.java
+++ b/src/test/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormTest.java
@@ -12,13 +12,16 @@ import org.keycloak.events.EventBuilder;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.http.HttpRequest;
 import org.keycloak.models.AuthenticationExecutionModel;
+import org.keycloak.models.AuthenticationFlowModel;
 import org.keycloak.models.AuthenticatorConfigModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.SubjectCredentialManager;
 import org.keycloak.models.UserModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -72,15 +75,19 @@ class EmailAuthenticatorFormTest {
     }
 
     @Test
-    @DisplayName("configuredFor returns true when the user has a non-blank email")
-    void testConfiguredFor_userWithEmail() {
+    @DisplayName("configuredFor returns true when the user has a stored email-authenticator credential")
+    void testConfiguredFor_withStoredCredential() {
         KeycloakSession session = mock(KeycloakSession.class);
         RealmModel realm = mock(RealmModel.class);
         UserModel user = mock(UserModel.class);
+        SubjectCredentialManager cm = mock(SubjectCredentialManager.class);
         when(user.getEmail()).thenReturn("alice@example.com");
+        when(user.credentialManager()).thenReturn(cm);
+        when(cm.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
+                .thenReturn(Stream.of(new EmailAuthenticatorCredentialModel()));
 
         assertTrue(authenticator.configuredFor(session, realm, user),
-                "Users with an email address must be eligible to receive an OTP without enrolment");
+                "An enrolled user must be reported as configured");
     }
 
     @Test
@@ -105,6 +112,91 @@ class EmailAuthenticatorFormTest {
 
         assertFalse(authenticator.configuredFor(session, realm, user),
                 "Blank emails should be treated as no email");
+    }
+
+    @Test
+    @DisplayName("configuredFor returns false by default for users with email but no stored credential — regression test for unwanted email-OTP prompt in Conditional - User Configured sub-flows (issue #108 follow-up)")
+    void testConfiguredFor_userWithEmail_noStoredCredential_noSkipSetupConfig_returnsFalse() {
+        KeycloakSession session = mock(KeycloakSession.class);
+        RealmModel realm = mock(RealmModel.class);
+        UserModel user = mock(UserModel.class);
+        SubjectCredentialManager cm = mock(SubjectCredentialManager.class);
+        when(user.getEmail()).thenReturn("alice@example.com");
+        when(user.credentialManager()).thenReturn(cm);
+        when(cm.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
+                .thenReturn(Stream.empty());
+        when(realm.getAuthenticationFlowsStream()).thenReturn(Stream.empty());
+
+        assertFalse(authenticator.configuredFor(session, realm, user),
+                "When no admin has opted in via skipSetup=true, a non-enrolled user must not be reported as configured — otherwise 'Conditional - User Configured' sub-flows trigger unexpectedly");
+    }
+
+    @Test
+    @DisplayName("configuredFor returns true when an admin has set skipSetup=true on any email-authenticator execution and the user has an email")
+    void testConfiguredFor_skipSetupTrue_userWithEmail_returnsTrue() {
+        KeycloakSession session = mock(KeycloakSession.class);
+        RealmModel realm = mock(RealmModel.class);
+        UserModel user = mock(UserModel.class);
+        SubjectCredentialManager cm = mock(SubjectCredentialManager.class);
+        AuthenticationFlowModel flow = mock(AuthenticationFlowModel.class);
+        AuthenticationExecutionModel exec = mock(AuthenticationExecutionModel.class);
+        AuthenticatorConfigModel cfg = mock(AuthenticatorConfigModel.class);
+
+        when(user.getEmail()).thenReturn("alice@example.com");
+        when(user.credentialManager()).thenReturn(cm);
+        when(cm.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
+                .thenReturn(Stream.empty());
+
+        when(flow.getId()).thenReturn("flow-1");
+        when(realm.getAuthenticationFlowsStream()).thenReturn(Stream.of(flow));
+        when(realm.getAuthenticationExecutionsStream("flow-1")).thenReturn(Stream.of(exec));
+        when(exec.getAuthenticator()).thenReturn(EmailAuthenticatorFormFactory.PROVIDER_ID);
+        when(exec.getAuthenticatorConfig()).thenReturn("cfg-1");
+        when(realm.getAuthenticatorConfigById("cfg-1")).thenReturn(cfg);
+        when(cfg.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "true"));
+
+        assertTrue(authenticator.configuredFor(session, realm, user),
+                "skipSetup=true is the explicit opt-in for the 'any user with email is eligible' behaviour");
+    }
+
+    @Test
+    @DisplayName("configuredFor returns false when skipSetup=true is opted in but the user has no email")
+    void testConfiguredFor_skipSetupTrue_noEmail_returnsFalse() {
+        KeycloakSession session = mock(KeycloakSession.class);
+        RealmModel realm = mock(RealmModel.class);
+        UserModel user = mock(UserModel.class);
+        when(user.getEmail()).thenReturn(null);
+
+        assertFalse(authenticator.configuredFor(session, realm, user),
+                "skipSetup cannot rescue a user with no email — the authenticator has nowhere to send the code");
+    }
+
+    @Test
+    @DisplayName("configuredFor returns false when skipSetup is explicitly false on every execution (issue #108 follow-up scenario)")
+    void testConfiguredFor_skipSetupFalseEverywhere_returnsFalse() {
+        KeycloakSession session = mock(KeycloakSession.class);
+        RealmModel realm = mock(RealmModel.class);
+        UserModel user = mock(UserModel.class);
+        SubjectCredentialManager cm = mock(SubjectCredentialManager.class);
+        AuthenticationFlowModel flow = mock(AuthenticationFlowModel.class);
+        AuthenticationExecutionModel exec = mock(AuthenticationExecutionModel.class);
+        AuthenticatorConfigModel cfg = mock(AuthenticatorConfigModel.class);
+
+        when(user.getEmail()).thenReturn("alice@example.com");
+        when(user.credentialManager()).thenReturn(cm);
+        when(cm.getStoredCredentialsByTypeStream(EmailAuthenticatorCredentialModel.TYPE_ID))
+                .thenReturn(Stream.empty());
+
+        when(flow.getId()).thenReturn("flow-1");
+        when(realm.getAuthenticationFlowsStream()).thenReturn(Stream.of(flow));
+        when(realm.getAuthenticationExecutionsStream("flow-1")).thenReturn(Stream.of(exec));
+        when(exec.getAuthenticator()).thenReturn(EmailAuthenticatorFormFactory.PROVIDER_ID);
+        when(exec.getAuthenticatorConfig()).thenReturn("cfg-1");
+        when(realm.getAuthenticatorConfigById("cfg-1")).thenReturn(cfg);
+        when(cfg.getConfig()).thenReturn(Map.of(EmailConstants.SKIP_SETUP, "false"));
+
+        assertFalse(authenticator.configuredFor(session, realm, user),
+                "An admin who explicitly disables skipSetup must get the strict, enrolment-only behaviour");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes a follow-up regression on issue #108 reported by @hashworks in [this comment](https://github.com/mesutpiskin/keycloak-2fa-email-authenticator/issues/108#issuecomment-4652667107):

> v26.4.2 didn't behave as expected on our end. With an authentication flow that shows 2FA forms if they are configured or the user has a specific attribute that enforces 2fa, the user was shown an email 2fa form even though the noted conditions aren't met. This doesn't happen with v26.4.1 and `skipSetup=false` in the whole flow.

### Root cause

PR #136 made `EmailAuthenticatorForm.configuredFor` return `true` for any user with an email address. Keycloak's `Conditional - User Configured` walks every sibling execution in the parent flow and calls `configuredFor` on each — so users who had neither enrolled the email authenticator nor matched the admin's other 2FA conditions were still being prompted for an email OTP.

### Fix

Restore `skipSetup` as the explicit opt-in for the "any user with email is eligible" behaviour, with a new default of `false` that matches Keycloak's convention for built-in authenticators.

`EmailAuthenticatorForm.configuredFor` now returns `true` when:
1. the user has a stored `email-authenticator` credential, **or**
2. the user has an email **and** at least one email-authenticator execution in the realm has `skipSetup=true`.

`EmailAuthenticatorCredentialProvider` is left untouched, preserving the architectural cleanup from #129 and the empty `userCredentialMetadatas` behaviour from #108.

### Trade-off, made explicit

| Use case | Setting |
| --- | --- |
| `Conditional - User Configured` sub-flow that should fire only for enrolled users (regression hashworks reported) | `skipSetup=false` (default) |
| Admin-provisioned 2FA without enrolment (#112), plugin visible in "Try Another Way" alternatives (#50) | `skipSetup=true` on the email-authenticator execution |

The admin UI config for `skipSetup` is restored with help text that calls out this trade-off.

### Backward compatibility

- Realms already on v26.3.1 / v26.4.1 with explicit `skipSetup=false` get the strict behaviour back without reconfiguration.
- Realms upgrading from v26.4.2 default behaviour need to set `skipSetup=true` on the execution if they were relying on the permissive default (e.g. to keep `Try Another Way` listing the plugin without enrolment).

## Test plan

- [x] `mvn test` — all 70 unit tests pass
- [x] `EmailAuthenticatorFormTest` — replaced `testConfiguredFor_userWithEmail` and added four cases: stored credential wins, regression scenario (email + no credential + no skipSetup → false), skipSetup=true opt-in with email, skipSetup=true cannot rescue users without an email, skipSetup=false everywhere stays strict
- [ ] Manual smoke test: `Conditional - User Configured` parent flow with email authenticator inside, user has email but no stored credential → conditional does **not** trigger
- [ ] Manual smoke test: same flow with `skipSetup=true` on the execution → conditional triggers and the email OTP form is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
