### PR TITLE
docs: link to sibling messaging-authenticator project in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Full documentation — installation, configuration, template customization, and 
 - Optional **masked email display** on the OTP form for better UX after the code is sent
 - Multiple email delivery backends: Keycloak SMTP, SendGrid, AWS SES, and Mailgun
 
+## Related projects
+
+Need OTP via SMS, Telegram, WhatsApp, or Signal? See the sibling project: **[keycloak-2fa-messaging-authenticator](https://github.com/mesutpiskin/keycloak-2fa-messaging-authenticator)** — same approach, different channel.
+
 ## Quick Start
 
 The easiest way to get the JAR is via Maven Central. Use the version matching your Keycloak installation:


### PR DESCRIPTION
## Summary

Adds a short "Related projects" section to the README between **Highlights** and **Quick Start**, pointing readers to the sibling messaging-based 2FA plugin:

> Need OTP via SMS, Telegram, WhatsApp, or Signal? See the sibling project: **[keycloak-2fa-messaging-authenticator](https://github.com/mesutpiskin/keycloak-2fa-messaging-authenticator)** — same approach, different channel.

Mirrored by the matching change in [keycloak-2fa-messaging-authenticator](https://github.com/mesutpiskin/keycloak-2fa-messaging-authenticator/pulls?q=is%3Apr+docs%2Fadd-related-projects-link) so the two projects discover each other.

## Test plan

- [x] README renders correctly on GitHub
- [x] Link resolves to the sibling repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
