### PR TITLE
feat: add auto-enrol option for users with verified email

### DIFF
--- a/docs/LOCAL_TESTING.md
+++ b/docs/LOCAL_TESTING.md
@@ -234,16 +234,27 @@ On "Email OTP" row:
 
 ### 6. Configure Email OTP Settings
 
-Click **⚙️ (Settings)** icon on "Email OTP" row:
+Click the **⚙️ (Settings)** icon on the "Email OTP" row:
 
-- **Code length:** 6
-- **Time-to-live:** 300 (5 minutes)
-- **Simulation mode:** false (for real emails)
-- **Resend cooldown:** 30 (seconds)
-- **Max code attempts:** 5
-- **Show Masked Email on OTP Form:** false by default
+| Setting | Default | Description |
+|---|---|---|
+| **Code length** | `6` | Number of digits in the OTP code |
+| **Time-to-live** | `300` | Seconds before the code expires |
+| **Simulation mode** | `false` | Log codes to server logs instead of sending emails |
+| **Resend cooldown** | `30` | Seconds before user can request a new code |
+| **Max code attempts** | `5` | Wrong attempts before code is invalidated |
+| **Show Masked Email on OTP Form** | `false` | Display a masked email (e.g. `u***e@example.com`) on the OTP screen |
+| **Skip setup** | `false` | Treat any user with an email as configured, even without enrollment |
+| **Auto-enrol if email verified** | `false` | Silently enroll users whose email is already verified, skipping the setup code |
 
-If you enable **Show Masked Email on OTP Form**, the login form shows a server-generated masked value such as `u***e@example.com` after the OTP is sent. This does not rely on `${user.email!}` being available in the Freemarker template context.
+**Show Masked Email on OTP Form:**
+If you enable this, the login form shows a server-generated masked value such as `u***e@example.com` after the OTP is sent. This does not rely on `${user.email!}` being available in the Freemarker template context.
+
+**Skip setup:**
+When `false` (the default), only users with a stored email-authenticator credential are reported as configured. This matches Keycloak's convention for built-in authenticators and ensures "Conditional - User Configured" sub-flows behave as expected. Set to `true` to allow any user with an email address to use email OTP without prior enrollment — useful for admin-provisioned accounts and for showing the plugin in Keycloak's "Try Another Way" alternative list.
+
+**Auto-enrol if email verified:**
+When enabled, the `email-authenticator-setup` required action enrolls users whose email is already verified silently. The credential is created without sending or asking for a setup code, since Keycloak has already proven the user controls the mailbox. Users with an unverified email always go through the normal code-verification flow. Only enable this if you trust how `emailVerified` is set in your realm.
 
 ---
 
@@ -295,11 +306,28 @@ Output:
 ***** SIMULATION MODE ***** Email code send to test@example.com for user testuser is: 123456
 ```
 
-### Test 6: Language Support (11 Languages)
+### Test 6: Masked Email Display
+
+1. In **Authentication → Flows**, open **⚙️** settings for **Email OTP**
+2. Enable **Show Masked Email on OTP Form**
+3. Login as `testuser`
+4. Expected: the OTP screen shows a masked destination such as `t***r@example.com`
+5. Confirm the full email address is not displayed
+
+### Test 7: Auto-enrol If Email Verified
+
+1. In **⚙️** settings for **Email OTP**, enable **Auto-enrol if email verified**
+2. Ensure `testuser` has **Email Verified: ON** (User Details tab)
+3. Add the `email-authenticator-setup` required action to the user
+4. Login as `testuser`
+5. Expected: the user is enrolled silently, no setup code is sent or requested
+6. Check logs for: `Auto-enrolled user testuser for Email 2FA (email already verified, setup code skipped)`
+
+### Test 8: Language Support (11 Languages)
 
 Change language on login page:
 - 🇹🇷 Türkçe
-- 🇬🇧 English  
+- 🇬🇧 English
 - 🇩🇪 Deutsch
 - 🇫🇷 Français
 - 🇮🇹 Italiano

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorFormFactory.java
@@ -130,7 +130,10 @@ public class EmailAuthenticatorFormFactory implements AuthenticatorFactory {
                         ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_SHOW_MASKED_EMAIL_ON_OTP_FORM)),
                 new ProviderConfigProperty(EmailConstants.SKIP_SETUP, "Treat any user with an email as configured",
                         "When enabled, users with an email address are reported as configured for the email authenticator even if they have never enrolled — useful for admin-provisioned 2FA and for showing the plugin in 'Try Another Way' alternatives. Leave disabled (default) when you rely on 'Conditional - User Configured' sub-flows: the conditional only triggers for users who have actually enrolled.",
-                        ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_SKIP_SETUP)));
+                        ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_SKIP_SETUP)),
+                new ProviderConfigProperty(EmailConstants.AUTO_ENROL_IF_EMAIL_VERIFIED, "Auto-enrol users whose email is already verified",
+                        "When enabled, the 'email-authenticator-setup' required action enrols users whose email is already verified silently — the credential is created without sending or asking for a setup code, since Keycloak has already proven the user controls the mailbox. Users with an unverified email still go through the normal code-verification flow. Only enable this if you trust how 'emailVerified' is set in your realm (admin-provisioned accounts, imports or IdP mappers can set it without a real verification).",
+                        ProviderConfigProperty.BOOLEAN_TYPE, String.valueOf(EmailConstants.DEFAULT_AUTO_ENROL_IF_EMAIL_VERIFIED)));
     }
 
     @Override

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorRequiredAction.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailAuthenticatorRequiredAction.java
@@ -56,14 +56,53 @@ public class EmailAuthenticatorRequiredAction implements RequiredActionProvider,
 
     @Override
     public void requiredActionChallenge(RequiredActionContext context) {
-        if (userMissingEmail(context.getUser())) {
+        UserModel user = context.getUser();
+        if (userMissingEmail(user)) {
             context.challenge(context.form()
                     .setError("email-authenticator-setup-missing-email")
                     .createForm(SETUP_TEMPLATE));
             return;
         }
 
+        // When the email is already verified, Keycloak has already proven the
+        // user controls the mailbox, so the setup verification code is redundant.
+        // If the admin opted in, enrol silently without sending a code.
+        boolean autoEnrolIfEmailVerified = Boolean.parseBoolean(
+                findAuthenticatorConfig(context).get(EmailConstants.AUTO_ENROL_IF_EMAIL_VERIFIED));
+        if (autoEnrolIfEmailVerified && user.isEmailVerified()) {
+            if (hasExistingCredential(user)) {
+                user.removeRequiredAction(PROVIDER_ID);
+                context.success();
+            } else if (persistCredentialAndComplete(context, user)) {
+                logger.infof("Auto-enrolled user %s for Email 2FA (email already verified, setup code skipped)",
+                        user.getUsername());
+            }
+            return;
+        }
+
         context.challenge(context.form().createForm(SETUP_TEMPLATE));
+    }
+
+    /**
+     * Creates and stores the email-authenticator credential for the user, then
+     * completes the required action. On persistence failure, re-challenges with
+     * the setup form and returns {@code false} so callers can stop early.
+     */
+    private boolean persistCredentialAndComplete(RequiredActionContext context, UserModel user) {
+        EmailAuthenticatorCredentialModel credential = EmailAuthenticatorCredentialModel.create();
+        credential.setUserLabel(user.getEmail());
+        try {
+            user.credentialManager().createStoredCredential(credential);
+        } catch (RuntimeException ex) {
+            logger.errorf(ex, "Failed to persist email authenticator credential for user %s", user.getId());
+            context.challenge(context.form()
+                    .setError("email-authenticator-setup-error")
+                    .createForm(SETUP_TEMPLATE));
+            return false;
+        }
+        user.removeRequiredAction(PROVIDER_ID);
+        context.success();
+        return true;
     }
 
     @Override
@@ -132,18 +171,7 @@ public class EmailAuthenticatorRequiredAction implements RequiredActionProvider,
         switch (result) {
             case VALID:
                 resetSetupCode(session);
-                EmailAuthenticatorCredentialModel credential = EmailAuthenticatorCredentialModel.create();
-                credential.setUserLabel(user.getEmail());
-                try {
-                    user.credentialManager().createStoredCredential(credential);
-                    user.removeRequiredAction(PROVIDER_ID);
-                    context.success();
-                } catch (RuntimeException ex) {
-                    logger.errorf(ex, "Failed to persist email authenticator credential for user %s", user.getId());
-                    context.challenge(context.form()
-                            .setError("email-authenticator-setup-error")
-                            .createForm(SETUP_TEMPLATE));
-                }
+                persistCredentialAndComplete(context, user);
                 break;
             case EXPIRED:
                 resetSetupCode(session);

--- a/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
+++ b/src/main/java/com/mesutpiskin/keycloak/auth/email/EmailConstants.java
@@ -230,6 +230,33 @@ public final class EmailConstants {
 	public static final boolean DEFAULT_SKIP_SETUP = false;
 
 	/**
+	 * Configuration key controlling whether the enrolment (required action)
+	 * auto-enrols users whose email address is already verified
+	 * ({@link org.keycloak.models.UserModel#isEmailVerified()}), skipping the
+	 * setup verification code.
+	 * <p>
+	 * When {@code true}, users whose email is already verified are enrolled
+	 * silently: the email-authenticator credential is created without sending or
+	 * asking for a setup code, because Keycloak has already proven the user
+	 * controls the mailbox. The credential is still stored, so email 2FA is
+	 * enforced on subsequent logins as usual.
+	 * </p>
+	 * <p>
+	 * Only opt in when you trust how {@code emailVerified} is set in your realm
+	 * (admin-provisioned accounts, imports or IdP mappers can set it without a
+	 * real verification). Users with an unverified email always go through the
+	 * normal code-verification flow regardless of this flag.
+	 * </p>
+	 */
+	public static final String AUTO_ENROL_IF_EMAIL_VERIFIED = "autoEnrolIfEmailVerified";
+
+	/**
+	 * Default value for {@link #AUTO_ENROL_IF_EMAIL_VERIFIED}. {@code false} is
+	 * the strict default: enrolment always requires a fresh verification code.
+	 */
+	public static final boolean DEFAULT_AUTO_ENROL_IF_EMAIL_VERIFIED = false;
+
+	/**
 	 * Millisecond rounding offset used for converting milliseconds to seconds.
 	 * Adding 999ms before division ensures proper ceiling rounding.
 	 */


### PR DESCRIPTION
Adds a new authenticator setting autoEnrolIfEmailVerified (default false) that allows the email-authenticator-setup required action to silently enroll users whose email is already verified, skipping the setup verification code. Since Keycloak has already proven the user controls the mailbox, the credential is created directly without sending or asking for a code.

Particularly useful for new users when the "Verify email" required action is set as a default action. Without this, we would need to send a second code after email verification.

Users with an unverified email always go through the normal code-verification flow regardless of this flag.

Changes:

EmailConstants: new AUTO_ENROL_IF_EMAIL_VERIFIED config key and false default
EmailAuthenticatorRequiredAction: auto-enrol path in requiredActionChallenge() when flag is enabled and email is verified ; 
extracted persistCredentialAndComplete() helper to dedupe credential persistence logic
EmailAuthenticatorFormFactory — new provider config property exposed in the admin console
docs/LOCAL_TESTING.md — updated settings table, added Test 7 for auto-enrol feature