### PR TITLE
Add Portuguese (pt) and Romanian (ro) translations

### DIFF
--- a/src/main/resources/theme-resources/messages/messages_pt.properties
+++ b/src/main/resources/theme-resources/messages/messages_pt.properties
@@ -1,0 +1,26 @@
+resendCode=Reenviar código
+emailOtpForm=Introduza o código de {0} dígitos que foi enviado para o seu email.
+
+emailCodeSubject=Código de acesso {0}
+emailCodeBody=Código de acesso: {0}.\n\nEste código expirará dentro de {1} segundos.
+emailCodeBodyHtml=<p>Código de acesso: <strong>{0}</strong>.</p><p>Este código expirará dentro de <strong>{1}</strong> segundos.</p>
+
+email-authenticator-display-name=Autenticador por email
+email-authenticator-help-text=Receba um código de verificação de utilização única por email.
+requiredAction.email-authenticator-setup=Configurar autenticador por email
+email-authenticator-setup-title=Configurar autenticador por email
+email-authenticator-setup-description=Utilize esta opção para receber códigos de verificação de utilização única por email durante o início de sessão.
+email-authenticator-setup-button=Ativar autenticador por email
+email-authenticator-setup-cancelled=A configuração do autenticador por email não pode ser cancelada.
+email-authenticator-setup-error=Não foi possível ativar o autenticador por email. Tente novamente ou contacte o suporte.
+email-authenticator-setup-missing-email=Adicione um endereço de email à sua conta antes de ativar o autenticador por email.
+email-authenticator-resend-cooldown=Aguarde {0} segundos antes de solicitar um novo código.
+email-authenticator-setup-verify-title=Verifique o seu email
+email-authenticator-setup-verify-description=Introduza o código de verificação de {0} dígitos enviado para o seu endereço de email.
+email-authenticator-setup-verify-button=Verificar
+email-authenticator-setup-send-error=Não foi possível enviar o email de verificação. Tente novamente.
+email-authenticator-setup-code-expired=O código de verificação expirou. Solicite um novo.
+email-authenticator-setup-code-invalid=O código de verificação está incorreto. Tente novamente.
+email-authenticator-setup-code-missing=Introduza o código de verificação.
+email-authenticator-setup-too-many-attempts=Demasiadas tentativas incorretas. Solicite um novo código.
+email-authenticator-too-many-attempts=Demasiadas tentativas incorretas. Solicite um novo código.

--- a/src/main/resources/theme-resources/messages/messages_ro.properties
+++ b/src/main/resources/theme-resources/messages/messages_ro.properties
@@ -1,0 +1,26 @@
+resendCode=Retrimite codul
+emailOtpForm=Vă rugăm să introduceți codul de {0} cifre trimis pe adresa dumneavoastră de email.
+
+emailCodeSubject=Cod de acces {0}
+emailCodeBody=Cod de acces: {0}.\n\nAcest cod va expira în {1} secunde.
+emailCodeBodyHtml=<p>Cod de acces: <strong>{0}</strong>.</p><p>Acest cod va expira în <strong>{1}</strong> secunde.</p>
+
+email-authenticator-display-name=Autentificator prin email
+email-authenticator-help-text=Primiți un cod de verificare de unică folosință prin email.
+requiredAction.email-authenticator-setup=Configurați autentificatorul prin email
+email-authenticator-setup-title=Configurați autentificatorul prin email
+email-authenticator-setup-description=Folosiți această opțiune pentru a primi coduri de verificare de unică folosință prin email la autentificare.
+email-authenticator-setup-button=Activați autentificatorul prin email
+email-authenticator-setup-cancelled=Configurarea autentificatorului prin email nu poate fi anulată.
+email-authenticator-setup-error=Nu am putut activa autentificatorul prin email. Încercați din nou sau contactați echipa de suport.
+email-authenticator-setup-missing-email=Adăugați o adresă de email la contul dumneavoastră înainte de a activa autentificatorul prin email.
+email-authenticator-resend-cooldown=Vă rugăm să așteptați {0} secunde înainte de a solicita un cod nou.
+email-authenticator-setup-verify-title=Verificați-vă adresa de email
+email-authenticator-setup-verify-description=Introduceți codul de verificare de {0} cifre trimis pe adresa dumneavoastră de email.
+email-authenticator-setup-verify-button=Verificare
+email-authenticator-setup-send-error=Nu a fost posibilă trimiterea emailului de verificare. Vă rugăm să încercați din nou.
+email-authenticator-setup-code-expired=Codul de verificare a expirat. Vă rugăm să solicitați unul nou.
+email-authenticator-setup-code-invalid=Codul de verificare este incorect. Vă rugăm să încercați din nou.
+email-authenticator-setup-code-missing=Vă rugăm să introduceți codul de verificare.
+email-authenticator-setup-too-many-attempts=Prea multe încercări incorecte. Vă rugăm să solicitați un cod nou.
+email-authenticator-too-many-attempts=Prea multe încercări incorecte. Vă rugăm să solicitați un cod nou.


### PR DESCRIPTION
## Summary

Adds `messages_pt.properties` and `messages_ro.properties` with translations for all keys currently present in `messages_en.properties`.

## Notes

- Portuguese follows European Portuguese (pt-PT) conventions.
- Both bundles follow the English file for `emailCodeBody` escaping (`\n\n`).
