### PR TITLE
Fix double-escaped newlines in emailCodeBody plain-text email body (8 locales)

### DIFF
--- a/src/main/resources/theme-resources/messages/messages_ar.properties
+++ b/src/main/resources/theme-resources/messages/messages_ar.properties
@@ -2,7 +2,7 @@ resendCode=إعادة إرسال الرمز
 emailOtpForm=الرجاء إدخال الرمز المكون من {0} أرقام الذي تم إرساله إلى بريدك الإلكتروني.
 
 emailCodeSubject={0} رمز الوصول
-emailCodeBody=رمز الوصول: {0}.\\n\\nستنتهي صلاحية هذا الرمز خلال {1} ثانية.
+emailCodeBody=رمز الوصول: {0}.\n\nستنتهي صلاحية هذا الرمز خلال {1} ثانية.
 emailCodeBodyHtml=<p>رمز الوصول: <strong>{0}</strong>.</p><p>ستنتهي صلاحية هذا الرمز خلال <strong>{1}</strong> ثانية.</p>
 
 email-authenticator-display-name=مصادقة البريد الإلكتروني

--- a/src/main/resources/theme-resources/messages/messages_az.properties
+++ b/src/main/resources/theme-resources/messages/messages_az.properties
@@ -2,7 +2,7 @@ resendCode=Kodu yenidən göndər
 emailOtpForm=Zəhmət olmasa e-poçtunuza göndərilən {0} rəqəmli kodu daxil edin.
 
 emailCodeSubject={0} giriş kodu
-emailCodeBody=Giriş kodu: {0}.\\n\\nBu kod {1} saniyə içində etibarsız olacaq.
+emailCodeBody=Giriş kodu: {0}.\n\nBu kod {1} saniyə içində etibarsız olacaq.
 emailCodeBodyHtml=<p>Giriş kodu: <strong>{0}</strong>.</p><p>Bu kod <strong>{1}</strong> saniyə içində etibarsız olacaq.</p>
 
 email-authenticator-display-name=E-poçt təsdiqləyici

--- a/src/main/resources/theme-resources/messages/messages_da.properties
+++ b/src/main/resources/theme-resources/messages/messages_da.properties
@@ -2,7 +2,7 @@ resendCode=Send kode igen
 emailOtpForm=Indtast venligst den {0}-cifrede kode, der blev leveret til din e-mail.
 
 emailCodeSubject={0} adgangskode
-emailCodeBody=Adgangskode: {0}.\\n\\nDenne kode udløber inden for {1} sekunder.
+emailCodeBody=Adgangskode: {0}.\n\nDenne kode udløber inden for {1} sekunder.
 emailCodeBodyHtml=<p>Adgangskode: <strong>{0}</strong>.</p><p>Denne kode udløber inden for <strong>{1}</strong> sekunder.</p>
 
 email-authenticator-display-name=E-mail-godkender

--- a/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/src/main/resources/theme-resources/messages/messages_de.properties
@@ -2,7 +2,7 @@ resendCode=Code erneut senden
 emailOtpForm=Bitte geben Sie den {0}-stelligen Code ein, der an Ihre E-Mail gesendet wurde.
 
 emailCodeSubject={0} Zugangscode
-emailCodeBody=Zugangscode: {0}.\\n\\nDieser Code läuft in {1} Sekunden ab.
+emailCodeBody=Zugangscode: {0}.\n\nDieser Code läuft in {1} Sekunden ab.
 emailCodeBodyHtml=<p>Zugangscode: <strong>{0}</strong>.</p><p>Dieser Code läuft in <strong>{1}</strong> Sekunden ab.</p>
 
 email-authenticator-display-name=E-Mail-Authentifikator

--- a/src/main/resources/theme-resources/messages/messages_es.properties
+++ b/src/main/resources/theme-resources/messages/messages_es.properties
@@ -2,7 +2,7 @@ resendCode=Reenviar código
 emailOtpForm=Por favor, introduzca el código de {0} dígitos que fue enviado a su correo electrónico.
 
 emailCodeSubject=Código de acceso {0}
-emailCodeBody=Código de acceso: {0}.\\n\\nEste código caducará en {1} segundos.
+emailCodeBody=Código de acceso: {0}.\n\nEste código caducará en {1} segundos.
 emailCodeBodyHtml=<p>Código de acceso: <strong>{0}</strong>.</p><p>Este código caducará en <strong>{1}</strong> segundos.</p>
 
 email-authenticator-display-name=Autenticador de correo electrónico

--- a/src/main/resources/theme-resources/messages/messages_ru.properties
+++ b/src/main/resources/theme-resources/messages/messages_ru.properties
@@ -2,7 +2,7 @@ resendCode=Отправить код повторно
 emailOtpForm=Пожалуйста, введите {0}-значный код, отправленный на вашу электронную почту.
 
 emailCodeSubject={0} код доступа
-emailCodeBody=Код доступа: {0}.\\n\\nЭтот код истечет через {1} секунд.
+emailCodeBody=Код доступа: {0}.\n\nЭтот код истечет через {1} секунд.
 emailCodeBodyHtml=<p>Код доступа: <strong>{0}</strong>.</p><p>Этот код истечет через <strong>{1}</strong> секунд.</p>
 
 email-authenticator-display-name=Аутентификатор электронной почты

--- a/src/main/resources/theme-resources/messages/messages_tr.properties
+++ b/src/main/resources/theme-resources/messages/messages_tr.properties
@@ -2,7 +2,7 @@ resendCode=Kodu Yeniden Gönder
 emailOtpForm=Lütfen e-posta adresinize gönderilen {0} haneli kodu girin.
 
 emailCodeSubject={0} erişim kodu
-emailCodeBody=Erişim kodu: {0}.\\n\\nBu kod {1} saniye içinde sona erecektir.
+emailCodeBody=Erişim kodu: {0}.\n\nBu kod {1} saniye içinde sona erecektir.
 emailCodeBodyHtml=<p>Erişim kodu: <strong>{0}</strong>.</p><p>Bu kod <strong>{1}</strong> saniye içinde sona erecektir.</p>
 
 email-authenticator-display-name=E-posta Doğrulayıcı

--- a/src/main/resources/theme-resources/messages/messages_zh_TW.properties
+++ b/src/main/resources/theme-resources/messages/messages_zh_TW.properties
@@ -2,7 +2,7 @@ resendCode=重送驗證碼
 emailOtpForm=請輸入發送至您電子郵件的 {0} 位數驗證碼。
 
 emailCodeSubject={0} 存取驗證碼
-emailCodeBody=一次性驗證碼: {0}.\\n\\n此驗證碼將於 {1} 秒後失效。
+emailCodeBody=一次性驗證碼: {0}.\n\n此驗證碼將於 {1} 秒後失效。
 emailCodeBodyHtml=<p>一次性驗證碼: <strong>{0}</strong>。</p><p>此驗證碼將於 <strong>{1}</strong> 秒後失效。</p>
 
 email-authenticator-display-name=電子郵件驗證器


### PR DESCRIPTION
## Summary

Fixes double-escaped newlines (`\\n\\n`) in `emailCodeBody` in 8 locales: ar, az, da, de, es, ru, tr, zh_TW. The en, fr and it bundles already use the correct `\n\n`.

## Problem

`java.util.Properties` unescapes `\\n` to a literal backslash + `n` (not a newline), so the **text/plain** part of the OTP email — rendered by `templates/text/code-email.ftl` via `msg("emailCodeBody", ...)` — contains a literal `\n\n` inline instead of a blank line for the affected locales. 

The HTML part (`emailCodeBodyHtml`, used by most mail clients) is unaffected, which makes this easy to miss.

Verified by loading the bundles with `Properties.load` + `MessageFormat`, mirroring how Keycloak renders theme message bundles. Before the fix, the Spanish body renders as a single line:

```
Código de acceso: 123456.\n\nEste código caducará en 300 segundos.
```

After the fix it renders with a proper blank line, matching the English bundle.

## Notes

- No wording changes — escaping only.
